### PR TITLE
docs: add user and developer guides

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,18 @@
+# Developer Guide
+
+## Repository Structure
+- `config/` – policy schema and branding assets.
+- `scripts/` – background and content scripts plus shared modules.
+- `rules/` – phishing detection rules.
+- `options/` – options page source.
+- `popup/` – popup UI code.
+- `styles/` – shared stylesheets.
+- `images/` – icons and images used throughout the extension.
+- `blocked.html` – page shown when a phishing attempt is blocked.
+- `manifest.json` – Chrome extension manifest.
+
+## Build & Packaging
+The extension runs directly in the browser without a build step. During development, load the project as an unpacked extension. For distribution, archive the directory (excluding development-only files) and deploy via your preferred mechanism.
+
+## Testing
+This repository does not include an automated test suite or npm scripts. Validate changes by loading the extension and exercising features manually.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,17 @@
+# User Guide
+
+## Installation
+- Clone the repository or download a release.
+- In Chrome, visit `chrome://extensions/` and enable **Developer mode**.
+- Choose **Load unpacked** and select the project directory.
+- For enterprise deployment, distribute the extension via Group Policy or Intune as described in the README.
+
+## Configuration
+- Policy definitions live in `config/managed_schema.json` and can be enforced through managed browser policies.
+- Customize branding by editing `config/branding.json`.
+- Edit `rules/detection-rules.json` to define custom phishing detection patterns.
+
+## Troubleshooting
+- **Extension fails to load**: Ensure Developer mode is enabled and the manifest is valid.
+- **Policies not applying**: Confirm the browser received the correct GPO or Intune configuration.
+- **Phishing detection not triggering**: Verify rules in the `rules/` directory and check that Microsoft 365 domains are accessible.


### PR DESCRIPTION
## Summary
- refine user guide configuration paths and rule references
- clarify developer guide structure and note lack of build or test scripts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b18442fe9c832b937ae21f6c6aa609