### PR TITLE
refactor: unify legitimacy score field

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -732,7 +732,7 @@ class CheckBackground {
             '<input name="loginfmt"><input name="idPartnerPL"><script>var urlMsaSignUp = "...";</script>',
           context: "form_analysis",
         },
-        expected: { hasRequiredElements: true, legitimacyScore: "high" },
+        expected: { hasRequiredElements: true, legitimacyLevel: "high" },
       },
     ];
   }

--- a/scripts/modules/detection-engine.js
+++ b/scripts/modules/detection-engine.js
@@ -598,7 +598,7 @@ export class DetectionEngine {
       content_length: content.length,
       context,
       findings: [],
-      legitimacy_score: 0,
+      legitimacyScore: 0,
       threat_level: "none",
       hasRequiredElements: false,
       // CyberDrain integration
@@ -651,7 +651,7 @@ export class DetectionEngine {
       }
 
       analysis.hasRequiredElements = foundElements >= 3; // At least 3 required elements
-      analysis.legitimacy_score =
+      analysis.legitimacyScore =
         (foundElements / requiredElements.length) * 100;
 
       // Check for phishing indicators
@@ -680,11 +680,11 @@ export class DetectionEngine {
 
       // CyberDrain integration - Enhanced legitimacy scoring
       if (analysis.aadLike && analysis.hasRequiredElements && analysis.threat_level === "none") {
-        analysis.legitimacyScore = "high";
-      } else if (analysis.legitimacy_score >= 60) {
-        analysis.legitimacyScore = "medium";
+        analysis.legitimacyLevel = "high";
+      } else if (analysis.legitimacyScore >= 60) {
+        analysis.legitimacyLevel = "medium";
       } else {
-        analysis.legitimacyScore = "low";
+        analysis.legitimacyLevel = "low";
       }
     } catch (error) {
       analysis.error = error.message;
@@ -1130,7 +1130,7 @@ export class DetectionEngine {
       content_length: content.length,
       context,
       findings: [],
-      legitimacy_score: 0,
+      legitimacyScore: 0,
       threat_level: "none",
       hasRequiredElements: false,
       // CyberDrain integration
@@ -1152,7 +1152,7 @@ export class DetectionEngine {
       
       // Calculate legitimacy score
       const totalElements = Object.keys(analysis.detectedElements).length;
-      analysis.legitimacy_score = totalElements > 0 ? (requiredCount / totalElements) * 100 : 0;
+      analysis.legitimacyScore = totalElements > 0 ? (requiredCount / totalElements) * 100 : 0;
       
       // Check for phishing indicators using rules
       if (this.detectionRules?.phishing_indicators) {
@@ -1177,11 +1177,11 @@ export class DetectionEngine {
       
       // Enhanced legitimacy scoring
       if (analysis.aadLike && analysis.hasRequiredElements && analysis.threat_level === "none") {
-        analysis.legitimacyScore = "high";
-      } else if (analysis.legitimacy_score >= 60) {
-        analysis.legitimacyScore = "medium";
+        analysis.legitimacyLevel = "high";
+      } else if (analysis.legitimacyScore >= 60) {
+        analysis.legitimacyLevel = "medium";
       } else {
-        analysis.legitimacyScore = "low";
+        analysis.legitimacyLevel = "low";
       }
       
     } catch (error) {

--- a/test-detection-rules-standalone.html
+++ b/test-detection-rules-standalone.html
@@ -253,7 +253,7 @@
                     content_length: content.length,
                     hasRequiredElements: false,
                     findings: [],
-                    legitimacy_score: 0
+                    legitimacyScore: 0
                 };
 
                 const requiredElements = [
@@ -272,7 +272,7 @@
                 }
 
                 analysis.hasRequiredElements = foundElements >= 2;
-                analysis.legitimacy_score = (foundElements / requiredElements.length) * 100;
+                analysis.legitimacyScore = (foundElements / requiredElements.length) * 100;
 
                 return analysis;
             }
@@ -483,7 +483,7 @@
                     <div style="margin: 5px 0; padding: 5px; border-left: 3px solid ${result.passed ? '#28a745' : '#dc3545'};">
                         <span style="font-weight: bold;">${status}</span>
                         ${result.url || result.referrer || result.test || 'Test'}
-                        ${result.analysis ? `<br><small>Score: ${result.analysis.legitimacy_score || 'N/A'}%</small>` : ''}
+                        ${result.analysis ? `<br><small>Score: ${result.analysis.legitimacyScore || 'N/A'}%</small>` : ''}
                     </div>
                 `;
             }


### PR DESCRIPTION
## Summary
- rename `legitimacy_score` to `legitimacyScore`
- add `legitimacyLevel` for textual classification
- update tests and background expectations to new names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b1dd001e68832b82b03264fc3fc787