### PR TITLE
Fix Microsoft login form action detection

### DIFF
--- a/rules/detection-rules.json
+++ b/rules/detection-rules.json
@@ -79,10 +79,10 @@
       "type": "form_action",
       "weight": 30,
       "condition": {
-        "not_contains": "login.microsoftonline.com",
+        "contains": "login.microsoftonline.com",
         "form_selector": "form[action]"
       },
-      "description": "Form POST URL must NOT be login.microsoftonline.com for legitimate pages"
+      "description": "Form POST URL must be login.microsoftonline.com for legitimate pages"
     },
     {
       "id": "detect_idpartnerpl_field",


### PR DESCRIPTION
## Summary
- require Microsoft login form actions to post to `login.microsoftonline.com`

## Testing
- `python -m json.tool rules/detection-rules.json`


------
https://chatgpt.com/codex/tasks/task_b_68b1f4df490c832b83a3f2414056f4cb