### PR TITLE
refactor: use default logger import

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -7,7 +7,7 @@
 import { ConfigManager } from "./modules/config-manager.js";
 import { DetectionEngine } from "./modules/detection-engine.js";
 import { PolicyManager } from "./modules/policy-manager.js";
-import { logger } from "./utils/logger.js";
+import logger from "./utils/logger.js";
 
 class CheckBackground {
   constructor() {


### PR DESCRIPTION
## Summary
- Use default logger export in background service worker to match logger utility

## Testing
- `node -e "global.chrome={storage:{local:{get:async()=>({}),set:async()=>{}}}}; import('./scripts/utils/logger.js').then(m=>{const logger=m.default; logger.init({output: console}); logger.log('background log test');});"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2b58970c8832b84d6112732241d9b