### PR TITLE
Load trusted origins from detection rules

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -454,7 +454,7 @@ class CheckContent {
       if (requirePw && !f.querySelector('input[type="password"]')) continue;
       const act = this.resolveAction(f.getAttribute("action"));
       const actOrigin = urlOrigin(act);
-      if (!trustedOrigins.has(actOrigin))
+      if (!(await isTrustedOrigin(actOrigin)))
         offenders.push({ action: act, actionOrigin: actOrigin });
     }
 


### PR DESCRIPTION
## Summary
- Build trusted origins list from `rules.trusted_origins` after loading rules
- Refactor origin/referrer checks to rely on the dynamically loaded list

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b2bcc352f4832bae90ac93e08f407f