### PR TITLE
Load trusted origins from detection rules

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -10,15 +10,18 @@
 
 import logger from "./utils/logger.js";
 
-// CyberDrain integration - Trusted origins
-const TRUSTED_ORIGINS = new Set([
+// CyberDrain integration - Precomputed Microsoft login origins
+const DEFAULT_TRUSTED_ORIGINS = [
   "https://login.microsoftonline.com",
   "https://login.microsoft.com",
   "https://login.windows.net",
   "https://login.microsoftonline.us",
   "https://login.partner.microsoftonline.cn",
-  "https://login.live.com"
-]);
+  "https://login.live.com",
+];
+
+let trustedOrigins = new Set(DEFAULT_TRUSTED_ORIGINS);
+let rulesLoaded = false;
 
 function urlOrigin(u) {
   try {
@@ -28,12 +31,22 @@ function urlOrigin(u) {
   }
 }
 
-function isTrustedOrigin(u) {
-  return TRUSTED_ORIGINS.has(urlOrigin(u));
+async function ensureRulesLoaded() {
+  if (!rulesLoaded) {
+    await rulesPromise;
+    rulesLoaded = true;
+  }
 }
 
-function isTrustedReferrer(ref) {
-  return ref && TRUSTED_ORIGINS.has(urlOrigin(ref));
+async function isTrustedOrigin(u) {
+  await ensureRulesLoaded();
+  return trustedOrigins.has(urlOrigin(u));
+}
+
+async function isTrustedReferrer(ref) {
+  if (!ref) return false;
+  await ensureRulesLoaded();
+  return trustedOrigins.has(urlOrigin(ref));
 }
 
 // Load detection rules: prefer cached rules, fall back to bundled JSON
@@ -57,12 +70,19 @@ async function loadRulesFast() {
 }
 
 // Shared promise for detection rules so early scan and main script use same data
-const rulesPromise = loadRulesFast();
+const rulesPromise = loadRulesFast().then((rules) => {
+  const origins = rules.trusted_origins
+    ? rules.trusted_origins.map((u) => urlOrigin(u))
+    : DEFAULT_TRUSTED_ORIGINS;
+  trustedOrigins = new Set(origins);
+  rulesLoaded = true;
+  return rules;
+});
 
 // Basic rule scoring and block action.
 // This is a lightweight early pass; the full DetectionEngine runs later.
 async function startDetection(rules) {
-  if (isTrustedOrigin(location.origin)) return;
+  if (await isTrustedOrigin(location.origin)) return;
   if (!rules) return;
   try {
     const html = document.documentElement.outerHTML;
@@ -258,7 +278,7 @@ class CheckContent {
     const origin = location.origin.toLowerCase();
 
     // 1) Real Microsoft login → show valid badge (if enabled)
-    if (isTrustedOrigin(origin)) {
+    if (await isTrustedOrigin(origin)) {
       // Check if valid page badge is enabled in settings
       const badgeEnabled = this.config?.enableValidPageBadge ||
                           this.policy?.EnableValidPageBadge ||
@@ -268,12 +288,12 @@ class CheckContent {
       if (badgeEnabled) {
         this.injectValidBadge(this.policy?.ValidPageBadgeImage, this.policy?.BrandingName);
       }
-      this.enforceMicrosoftActionIfConfigured();
+      await this.enforceMicrosoftActionIfConfigured();
       return;
     }
 
     // 2) Post-login redirect from real login (no password field) → trusted-by-referrer
-    if (isTrustedReferrer(document.referrer) && !this.hasPassword()) {
+    if (await isTrustedReferrer(document.referrer) && !this.hasPassword()) {
       chrome.runtime.sendMessage({ type: "FLAG_TRUSTED_BY_REFERRER" });
       return;
     }
@@ -318,10 +338,10 @@ class CheckContent {
         const analysis = response.analysis;
         
         // Use rule-driven detection results
-        if (analysis.aadLike && !isTrustedOrigin(origin)) {
+        if (analysis.aadLike && !(await isTrustedOrigin(origin))) {
           // Check additional rule-based conditions
-          const actionCheck = this.checkFormActions(analysis.detectedElements.password_field);
-          const resourceAudit = this.auditSubresourceOrigins();
+          const actionCheck = await this.checkFormActions(analysis.detectedElements.password_field);
+          const resourceAudit = await this.auditSubresourceOrigins();
           
           const requireAction = this.policy?.RequireMicrosoftAction !== false;
           const strictAudit = this.policy?.StrictResourceAudit !== false;
@@ -343,7 +363,7 @@ class CheckContent {
     } catch (error) {
       logger.error("Check: Rule-driven analysis failed, falling back to basic detection:", error);
       // Fallback to basic detection if rule-driven analysis fails
-      this.evaluateAADFingerprintBasic();
+      await this.evaluateAADFingerprintBasic();
     }
   }
 
@@ -362,7 +382,7 @@ class CheckContent {
   }
 
   // Fallback basic detection method
-  evaluateAADFingerprintBasic() {
+  async evaluateAADFingerprintBasic() {
     const origin = location.origin.toLowerCase();
     
     // Basic AAD fingerprint
@@ -373,9 +393,9 @@ class CheckContent {
     const brandingHit = /\b(Microsoft\s*365|Office\s*365|Entra\s*ID|Azure\s*AD|Microsoft)\b/i.test(text);
     const aadLike = (hasLoginFmt && hasNextBtn) || (brandingHit && (hasLoginFmt || hasPw));
 
-    if (aadLike && !isTrustedOrigin(origin)) {
-      const actionCheck = this.checkFormActions(hasPw);
-      const resourceAudit = this.auditSubresourceOrigins();
+    if (aadLike && !(await isTrustedOrigin(origin))) {
+      const actionCheck = await this.checkFormActions(hasPw);
+      const resourceAudit = await this.auditSubresourceOrigins();
       
       this.flagged = true;
       this.injectRedBanner(this.policy?.BrandingName, actionCheck, resourceAudit);
@@ -393,22 +413,25 @@ class CheckContent {
     return !!document.querySelector('input[type="password"]');
   }
 
-  enforceMicrosoftActionIfConfigured() {
+  async enforceMicrosoftActionIfConfigured() {
     const requireAction = this.policy?.RequireMicrosoftAction !== false;
     if (!requireAction) return;
-    
+
+    await ensureRulesLoaded();
+
     const forms = Array.from(document.querySelectorAll("form"));
     const bad = [];
-    
+
     for (const f of forms) {
       const hasPw = !!f.querySelector('input[type="password"]');
       if (!hasPw) continue;
       const act = this.resolveAction(f.getAttribute("action"));
       const actOrigin = urlOrigin(act);
-      if (!isTrustedOrigin(actOrigin)) bad.push({action: actOrigin});
+      if (!trustedOrigins.has(actOrigin)) bad.push({ action: actOrigin });
     }
-    
-    if (bad.length) this.showToast("Unusual: password form posts outside Microsoft login.");
+
+    if (bad.length)
+      this.showToast("Unusual: password form posts outside Microsoft login.");
   }
 
   resolveAction(a) {
@@ -417,31 +440,36 @@ class CheckContent {
     return act;
   }
 
-  checkFormActions(requirePw) {
+  async checkFormActions(requirePw) {
+    await ensureRulesLoaded();
     const forms = Array.from(document.querySelectorAll("form"));
     const offenders = [];
-    
+
     for (const f of forms) {
       if (requirePw && !f.querySelector('input[type="password"]')) continue;
       const act = this.resolveAction(f.getAttribute("action"));
       const actOrigin = urlOrigin(act);
-      if (!isTrustedOrigin(actOrigin)) offenders.push({ action: act, actionOrigin: actOrigin });
+      if (!trustedOrigins.has(actOrigin))
+        offenders.push({ action: act, actionOrigin: actOrigin });
     }
-    
-    return offenders.length ? { fail: true, reason: "non-microsoft-form-action", offenders } : { fail: false };
+
+    return offenders.length
+      ? { fail: true, reason: "non-microsoft-form-action", offenders }
+      : { fail: false };
   }
 
-  auditSubresourceOrigins() {
+  async auditSubresourceOrigins() {
+    await ensureRulesLoaded();
     const nodes = [
       ...document.querySelectorAll('script[src]'),
       ...document.querySelectorAll('link[rel="stylesheet"][href]'),
       ...document.querySelectorAll('img[src]')
     ];
-    
+
     const origins = new Set();
     const nonMs = new Set();
     const origin = location.origin.toLowerCase();
-    
+
     for (const el of nodes) {
       const url = el.src || el.href;
       if (!url) continue;
@@ -449,9 +477,9 @@ class CheckContent {
       if (!o) continue;
       origins.add(o);
       // If all assets are on the same fake origin, this may yield 0 — that's fine.
-      if (!isTrustedOrigin(o) && o !== origin) nonMs.add(o);
+      if (!trustedOrigins.has(o) && o !== origin) nonMs.add(o);
     }
-    
+
     return {
       origins: Array.from(origins),
       nonMicrosoft: Array.from(nonMs),


### PR DESCRIPTION
## Summary
- Build trusted origins list from `rules.trusted_origins` after loading rules
- Seed default Microsoft login origins and wait for rule loading before origin/referrer checks
- Guard against repeated awaits by toggling `rulesLoaded` after the rules promise resolves

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check scripts/content.js`


------
https://chatgpt.com/codex/tasks/task_b_68b2bcc352f4832bae90ac93e08f407f