### PR TITLE
Load trusted origins from detection rules

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -35,9 +35,11 @@ async function ensureRulesLoaded() {
   if (!rulesLoaded) await rulesPromise;
 }
 
-async function isTrustedOrigin(origin) {
+async function isTrustedOrigin(originOrUrl) {
   await ensureRulesLoaded();
-  return trustedOrigins.has((origin || "").toLowerCase());
+  // Accepts either a full URL or an origin string
+  const origin = urlOrigin(originOrUrl || "");
+  return trustedOrigins.has(origin);
 }
 
 async function isTrustedReferrer(origin) {


### PR DESCRIPTION
## Summary
- Build trusted origins list from `rules.trusted_origins` after loading rules
- Seed default Microsoft login origins and wait for rule loading before origin/referrer checks
- Guard against repeated awaits by toggling `rulesLoaded` after the rules promise resolves
- Use `isTrustedOrigin` in action, form, and subresource checks so origin decisions defer until rules finish loading
- Normalize origin helpers to accept pre-parsed origins and pass `urlOrigin` results for form and referrer checks
- Remove duplicate `rulesLoaded` toggle in `ensureRulesLoaded` to avoid race conditions
- Normalize origin validation by lowercasing inside `isTrustedOrigin`/`isTrustedReferrer` and dropping per-call `toLowerCase`

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check scripts/content.js`


------
https://chatgpt.com/codex/tasks/task_b_68b2bcc352f4832bae90ac93e08f407f