### PR TITLE
Harden rule loader and handle invalid trusted origins

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -35,9 +35,6 @@ async function ensureRulesLoaded() {
   if (!rulesPromise) {
     rulesPromise = loadRulesFast()
       .then((rules) => {
-        const origins = rules.trusted_origins
-          ? rules.trusted_origins.map(urlOrigin).filter(origin => origin !== null)
-          ? rules.trusted_origins.map(urlOrigin).filter(origin => origin !== null)
           : DEFAULT_TRUSTED_ORIGINS.map(urlOrigin).filter(origin => origin !== null);
         trustedOrigins = new Set(origins);
         return rules;


### PR DESCRIPTION
## Summary
- Lazily load detection rules with centralized promise and error handling
- Filter out invalid URLs when populating trusted origins
- Treat invalid input as untrusted in `isTrustedOrigin`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2d6a7b100832b8e4012403ab3880e