### PR TITLE
Fix trusted origins ternary in content script

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -35,6 +35,8 @@ async function ensureRulesLoaded() {
   if (!rulesPromise) {
     rulesPromise = loadRulesFast()
       .then((rules) => {
+        const origins = rules.trusted_origins
+          ? rules.trusted_origins.map(urlOrigin).filter(origin => origin !== null)
           : DEFAULT_TRUSTED_ORIGINS.map(urlOrigin).filter(origin => origin !== null);
         trustedOrigins = new Set(origins);
         return rules;


### PR DESCRIPTION
## Summary
- Fix orphaned ternary operator when loading trusted origins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2e8b1ee68832ba5dc48522c4f4b7c