### PR TITLE
fix: remove module type from content script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,8 +23,7 @@
       "js": ["scripts/content.js"],
       "css": ["styles/content.css"],
       "run_at": "document_start",
-      "all_frames": true,
-      "type": "module"
+      "all_frames": true
     }
   ],
   "action": {


### PR DESCRIPTION
## Summary
- remove "type": "module" from the content script entry in manifest.json

## Testing
- `npx eslint scripts options popup` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68b35d89facc832b9c4e7b60e9159576