### PR TITLE
fix: dynamically import logger in content script

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -11,22 +11,20 @@
 let logger = console;
 
 (async () => {
-  async function loadLogger() {
-    try {
-      const mod = await import(chrome.runtime.getURL("scripts/utils/logger.js"));
-      logger = mod.default;
-    } catch (err) {
-      console.error("Failed to load logger:", err);
-    }
+  try {
+    const mod = await import(
+      chrome.runtime.getURL("scripts/utils/logger.js")
+    );
+    logger = mod.default;
+  } catch (err) {
+    logger.error("Failed to load logger:", err);
   }
-
-  await loadLogger();
 
   chrome.runtime.sendMessage({ type: "ping" }, (response) => {
     if (chrome.runtime.lastError) {
-      console.error("Ping error:", chrome.runtime.lastError.message);
+      logger.error("Ping error:", chrome.runtime.lastError.message);
     } else {
-      console.log("Ping response:", response);
+      logger.log("Ping response:", response);
     }
   });
 


### PR DESCRIPTION
## Summary
- wrap content script in async IIFE
- dynamically load logger module
- expose logger outside try-catch for use throughout script

## Testing
- `node --check scripts/content.js`
- `npx eslint scripts options popup` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68b35f9706bc832b9a88b93b13d3f624