### PR TITLE
fix: skip content script on browser pages

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -550,6 +550,35 @@ class CheckBackground {
 
   async injectContentScript(tabId) {
     try {
+      const tab = await chrome.tabs.get(tabId);
+      const url = tab?.url;
+      if (!url) {
+        logger.warn("Check: No URL for tab", tabId);
+        return;
+      }
+
+      let protocol;
+      try {
+        protocol = new URL(url).protocol;
+      } catch {
+        logger.warn("Check: Invalid URL, skipping content script:", url);
+        return;
+      }
+
+      const disallowed = [
+        "chrome:",
+        "edge:",
+        "about:",
+        "chrome-extension:",
+        "moz-extension:",
+        "devtools:",
+      ];
+
+      if (disallowed.includes(protocol)) {
+        logger.warn("Check: Skipping content script injection for disallowed URL:", url);
+        return;
+      }
+
       await chrome.scripting.executeScript({
         target: { tabId },
         files: ["scripts/content.js"],


### PR DESCRIPTION
## Summary
- guard content script injection by checking tab URL scheme
- warn and skip if scheme is disallowed (chrome, edge, about, extension, devtools)

## Testing
- `npx eslint scripts options popup` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68b35fc80580832b9aa69ec8e95ca7b5