### PR TITLE
DOCS: Fix typo in companyURL property assignment in deployment instructions

### DIFF
--- a/docs/deployment/chrome-edge-deployment-instructions.md
+++ b/docs/deployment/chrome-edge-deployment-instructions.md
@@ -196,7 +196,7 @@ function Configure-ExtensionSettings {
 
     # Set custom branding settings
     New-ItemProperty -Path $customBrandingKey -Name "companyName" -PropertyType String -Value $companyName -Force | Out-Null
-    New-ItemProperty -Path $cusomtBrandingKey -Name "companyURL" -PropertyType String -Value $companyURL -Force | Out-Null
+    New-ItemProperty -Path $customBrandingKey -Name "companyURL" -PropertyType String -Value $companyURL -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "productName" -PropertyType String -Value $productName -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "supportEmail" -PropertyType String -Value $supportEmail -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "primaryColor" -PropertyType String -Value $primaryColor -Force | Out-Null


### PR DESCRIPTION
Fixes Small typo in chrome-edge-deployment-instructions.md

Fixes #56 