### PR TITLE
New Store Release Link, Typo and Inclusivity

### DIFF
--- a/config/managed_schema.json
+++ b/config/managed_schema.json
@@ -53,14 +53,14 @@
       "maximum": 168,
       "default": 24
     },
-    "urlWhitelist": {
-      "title": "URL Whitelist (URLs with wildcards or Regex)",
-      "description": "Array of URL patterns or regex patterns to whitelist URLs from detection. Supports simple URLs with * wildcards (e.g., https://google.com/*) or advanced regex patterns.",
+    "urlAllowlist": {
+      "title": "URL Allowlist (URLs with wildcards or Regex)",
+      "description": "Array of URL patterns or regex patterns to allowlist URLs from detection. Supports simple URLs with * wildcards (e.g., https://google.com/*) or advanced regex patterns.",
       "type": "array",
       "items": {
         "type": "string",
         "title": "URL Pattern or Regex",
-        "description": "URL with wildcards (e.g., https://google.com/*) or regular expression pattern to match URLs that should be whitelisted"
+        "description": "URL with wildcards (e.g., https://google.com/*) or regular expression pattern to match URLs that should be allowlisted"
       },
       "default": []
     },

--- a/enterprise/admx/Check-Extension.admx
+++ b/enterprise/admx/Check-Extension.admx
@@ -131,12 +131,12 @@
       </elements>
     </policy>
 
-    <!-- URL Whitelist -->
-    <policy name="CheckUrlWhitelist" class="Machine" displayName="$(string.CheckUrlWhitelist)" explainText="$(string.CheckUrlWhitelist_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy" presentation="$(presentation.CheckUrlWhitelist)">
+    <!-- URL Allowlist -->
+    <policy name="CheckUrlAllowlist" class="Machine" displayName="$(string.CheckUrlAllowlist)" explainText="$(string.CheckUrlAllowlist_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy" presentation="$(presentation.CheckUrlAllowlist)">
       <parentCategory ref="CheckExtensionEdge" />
       <supportedOn ref="SUPPORTED_WIN7" />
       <elements>
-        <list id="UrlWhitelistList" valueName="urlWhitelist" />
+        <list id="UrlAllowlistList" valueName="urlAllowlist" />
       </elements>
     </policy>
 
@@ -306,12 +306,12 @@
       </elements>
     </policy>
 
-    <!-- URL Whitelist - Chrome -->
-    <policy name="CheckUrlWhitelistChrome" class="Machine" displayName="$(string.CheckUrlWhitelistChrome)" explainText="$(string.CheckUrlWhitelistChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy" presentation="$(presentation.CheckUrlWhitelistChrome)">
+    <!-- URL Allowlist - Chrome -->
+    <policy name="CheckUrlAllowlistChrome" class="Machine" displayName="$(string.CheckUrlAllowlistChrome)" explainText="$(string.CheckUrlAllowlistChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy" presentation="$(presentation.CheckUrlAllowlistChrome)">
       <parentCategory ref="CheckExtensionChrome" />
       <supportedOn ref="SUPPORTED_WIN7" />
       <elements>
-        <list id="UrlWhitelistListChrome" valueName="urlWhitelist" />
+        <list id="UrlAllowlistListChrome" valueName="urlAllowlist" />
       </elements>
     </policy>
 

--- a/enterprise/admx/en-US/Check-Extension.adml
+++ b/enterprise/admx/en-US/Check-Extension.adml
@@ -111,9 +111,9 @@ Range: 1-168 hours (1 hour to 1 week)
 
 More frequent updates provide better protection but may increase network usage.</string>
 
-      <!-- URL Whitelist -->
-      <string id="CheckUrlWhitelist">URL whitelist (URLs with wildcards or regex patterns)</string>
-      <string id="CheckUrlWhitelist_Explain">This policy specifies a list of URL patterns or regex patterns to whitelist URLs from detection.
+      <!-- URL Allowlist -->
+      <string id="CheckUrlAllowlist">URL allowlist (URLs with wildcards or regex patterns)</string>
+      <string id="CheckUrlAllowlist_Explain">This policy specifies a list of URL patterns or regex patterns to allowlist URLs from detection.
 
 These patterns will be added to the exclusion rules without replacing the entire ruleset. You can use simple URLs with wildcards or advanced regex patterns.
 
@@ -128,9 +128,9 @@ Advanced regex examples:
 
 URLs matching any of these patterns will bypass phishing detection.</string>
 
-      <!-- URL Whitelist - Chrome -->
-      <string id="CheckUrlWhitelistChrome">URL whitelist (URLs with wildcards or regex patterns) (Chrome)</string>
-      <string id="CheckUrlWhitelistChrome_Explain">This policy specifies a list of URL patterns or regex patterns to whitelist URLs from detection in Google Chrome.
+      <!-- URL Allowlist - Chrome -->
+      <string id="CheckUrlAllowlistChrome">URL allowlist (URLs with wildcards or regex patterns) (Chrome)</string>
+      <string id="CheckUrlAllowlistChrome_Explain">This policy specifies a list of URL patterns or regex patterns to allowlist URLs from detection in Google Chrome.
 
 These patterns will be added to the exclusion rules without replacing the entire ruleset. You can use simple URLs with wildcards or advanced regex patterns.
 
@@ -388,11 +388,11 @@ The logo should be a square image (recommended size: 48x48 to 128x128 pixels) in
           <label>Logo URL:</label>
         </textBox>
       </presentation>
-      <presentation id="CheckUrlWhitelist">
-        <listBox refId="UrlWhitelistList">URL Whitelist (URLs with wildcards or regex patterns):</listBox>
+      <presentation id="CheckUrlAllowlist">
+        <listBox refId="UrlAllowlistList">URL Allowlist (URLs with wildcards or regex patterns):</listBox>
       </presentation>
-      <presentation id="CheckUrlWhitelistChrome">
-        <listBox refId="UrlWhitelistListChrome">URL Whitelist (URLs with wildcards or regex patterns):</listBox>
+      <presentation id="CheckUrlAllowlistChrome">
+        <listBox refId="UrlAllowlistListChrome">URL Allowlist (URLs with wildcards or regex patterns):</listBox>
       </presentation>
     </presentationTable>
   </resources>

--- a/options/options.html
+++ b/options/options.html
@@ -164,10 +164,10 @@
 
                         <div class="setting-item">
                             <label class="setting-label">
-                                URL Whitelist (Regex or URL with wildcards)
-                                <textarea id="urlWhitelist" class="setting-textarea" rows="6" placeholder="Enter URLs or regex patterns, one per line:&#10;&#10;Simple URLs with wildcards:&#10;https://google.com/*&#10;https://*.microsoft.com/*&#10;&#10;Advanced regex patterns:&#10;^https://trusted\.example\.com/.*"></textarea>
+                                URL Allowlist (Regex or URL with wildcards)
+                                <textarea id="urlAllowlist" class="setting-textarea" rows="6" placeholder="Enter URLs or regex patterns, one per line:&#10;&#10;Simple URLs with wildcards:&#10;https://google.com/*&#10;https://*.microsoft.com/*&#10;&#10;Advanced regex patterns:&#10;^https://trusted\.example\.com/.*"></textarea>
                             </label>
-                            <p class="setting-description">Add URLs or regex patterns to whitelist from detection. Use simple URLs with * wildcards (e.g., https://google.com/*) or advanced regex patterns. These will be added to the exclusion rules without replacing the entire ruleset.</p>
+                            <p class="setting-description">Add URLs or regex patterns to allowlist from detection. Use simple URLs with * wildcards (e.g., https://google.com/*) or advanced regex patterns. These will be added to the exclusion rules without replacing the entire ruleset.</p>
                         </div>
 
                         <div class="setting-item">

--- a/options/options.html
+++ b/options/options.html
@@ -363,7 +363,18 @@
                         <div class="about-section-spacer"></div>
 
                         <div class="links-grid">
-                                    <a href="https://chromewebstore.google.com/detail/benimdeioplgkhanklclahllklceahbe/?hl=en-GB&authuser=0" target="_blank" class="link-card">
+						            <a href="https://microsoftedge.microsoft.com/addons/detail/check-by-cyberdrain/knepjpocdagponkonnbggpcnhnaikajg" target="_blank" class="link-card">
+                                        <div class="link-icon">
+                                            <span class="material-icons">store</span>
+                                        </div>
+                                        <div class="link-content">
+                                            <h4>Edge Web Store</h4>
+                                            <p>Download and rate this extension</p>
+                                        </div>
+                                        <span class="material-icons link-arrow">open_in_new</span>
+                                    </a>
+									
+                                    <a href="https://chromewebstore.google.com/detail/check-by-cyberdrain/benimdeioplgkhanklclahllklceahbe" target="_blank" class="link-card">
                                         <div class="link-icon">
                                             <span class="material-icons">store</span>
                                         </div>
@@ -385,7 +396,7 @@
                                         <span class="material-icons link-arrow">open_in_new</span>
                                     </a>
 
-                                    <a href="https://cyberdrain.com" target="_blank" class="link-card">
+                                    <a href="https://cyberdrain.com/" target="_blank" class="link-card">
                                         <div class="link-icon">
                                             <span class="material-icons">language</span>
                                         </div>

--- a/options/options.js
+++ b/options/options.js
@@ -2017,7 +2017,7 @@ class CheckOptions {
           // Custom branding (matches managed_schema.json structure)
           customBranding: {
             companyName: "CyberDrain",
-			CompanyURL: "https://cyberdrain.com/",
+			companyURL: "https://cyberdrain.com/",
             productName: "Check Enterprise",
             primaryColor: "#F77F00",
             logoUrl:

--- a/options/options.js
+++ b/options/options.js
@@ -56,7 +56,7 @@ class CheckOptions {
     // Detection settings
     this.elements.customRulesUrl = document.getElementById("customRulesUrl");
     this.elements.updateInterval = document.getElementById("updateInterval");
-    this.elements.urlWhitelist = document.getElementById("urlWhitelist");
+    this.elements.urlAllowlist = document.getElementById("urlAllowlist");
     this.elements.refreshDetectionRules = document.getElementById(
       "refreshDetectionRules"
     );
@@ -575,12 +575,12 @@ class CheckOptions {
       this.config?.customRulesUrl ||
       "";
 
-    // URL Whitelist settings
-    if (this.elements.urlWhitelist) {
-      const whitelist = this.config?.urlWhitelist || [];
-      this.elements.urlWhitelist.value = Array.isArray(whitelist)
-        ? whitelist.join('\n')
-        : (whitelist || '');
+    // URL Allowlist settings
+    if (this.elements.urlAllowlist) {
+      const allowlist = this.config?.urlAllowlist || [];
+      this.elements.urlAllowlist.value = Array.isArray(allowlist)
+        ? allowlist.join('\n')
+        : (allowlist || '');
     }
 
     // Handle updateInterval - ensure we always show hours in the UI
@@ -799,9 +799,9 @@ class CheckOptions {
       customRulesUrl: this.elements.customRulesUrl?.value || "",
       updateInterval: parseInt(this.elements.updateInterval?.value || 24),
       
-      // URL Whitelist settings
-      urlWhitelist: this.elements.urlWhitelist?.value
-        ? this.elements.urlWhitelist.value.split('\n').filter(line => line.trim())
+      // URL Allowlist settings
+      urlAllowlist: this.elements.urlAllowlist?.value
+        ? this.elements.urlAllowlist.value.split('\n').filter(line => line.trim())
         : [],
 
       // Debug logging setting
@@ -856,15 +856,15 @@ class CheckOptions {
       return { valid: false, message: "Custom rules URL is not valid" };
     }
 
-    // URL Whitelist validation
-    if (config.urlWhitelist && Array.isArray(config.urlWhitelist)) {
-      for (const pattern of config.urlWhitelist) {
+    // URL Allowlist validation
+    if (config.urlAllowlist && Array.isArray(config.urlAllowlist)) {
+      for (const pattern of config.urlAllowlist) {
         if (pattern.trim()) {
           const validationResult = this.validateUrlPattern(pattern.trim());
           if (!validationResult.valid) {
             return {
               valid: false,
-              message: `Invalid pattern in URL whitelist: "${pattern.trim()}" - ${validationResult.error}`
+              message: `Invalid pattern in URL allowlist: "${pattern.trim()}" - ${validationResult.error}`
             };
           }
         }
@@ -2153,7 +2153,7 @@ class CheckOptions {
       cippTenantId: this.elements.cippTenantId,
       customRulesUrl: this.elements.customRulesUrl,
       updateInterval: this.elements.updateInterval,
-      urlWhitelist: this.elements.urlWhitelist,
+      urlAllowlist: this.elements.urlAllowlist,
       enableDebugLogging: this.elements.enableDebugLogging,
       // Note: enableDeveloperConsoleLogging is excluded - should remain available for debugging
       // Branding fields (if customBranding policy is present)

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -295,7 +295,7 @@ class CheckBackground {
 
     // CyberDrain integration
     this.policy = null;
-    this.extraWhitelist = new Set();
+    this.extraAllowlist = new Set();
     this.tabHeaders = new Map();
     this.HEADER_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
     this.MAX_HEADER_CACHE_ENTRIES = 100;
@@ -454,7 +454,7 @@ class CheckBackground {
     return {
       BrandingName: "CyberDrain Check Phishing Protection",
       BrandingImage: "",
-      ExtraWhitelist: [],
+      ExtraAllowlist: [],
       CIPPReportingServer: "",
       AlertWhenLogon: true,
       ValidPageBadgeImage: "",
@@ -470,8 +470,8 @@ class CheckBackground {
       // Load policy from policy manager
       const policyData = await this.policyManager.getPolicies();
       this.policy = policyData || this.getDefaultPolicy();
-      this.extraWhitelist = new Set(
-        (this.policy?.ExtraWhitelist || [])
+      this.extraAllowlist = new Set(
+        (this.policy?.ExtraAllowlist || [])
           .map((s) => this.urlOrigin(s))
           .filter(Boolean)
       );
@@ -482,7 +482,7 @@ class CheckBackground {
         error
       );
       this.policy = this.getDefaultPolicy();
-      this.extraWhitelist = new Set();
+      this.extraAllowlist = new Set();
     }
   }
 
@@ -506,7 +506,7 @@ class CheckBackground {
         "https://account.microsoft.com",
       ]);
     if (trustedOrigins.has && trustedOrigins.has(origin)) return "trusted";
-    if (this.extraWhitelist.has(origin)) return "trusted-extra";
+    if (this.extraAllowlist.has(origin)) return "trusted-extra";
     return "not-evaluated"; // Changed from "unknown" - don't show badge until we know it's relevant
   }
 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1919,7 +1919,7 @@ if (window.checkExtensionLoaded) {
 
   /**
    * Check if domain should be excluded from phishing detection
-   * Now includes both detection rules exclusions AND user-configured URL whitelist
+   * Now includes both detection rules exclusions AND user-configured URL allowlist
    */
   function checkDomainExclusion(url) {
     if (detectionRules?.exclusion_system?.domain_patterns) {
@@ -1939,26 +1939,26 @@ if (window.checkExtensionLoaded) {
         return true;
       }
     }
-    return checkUserUrlWhitelist(url);
+    return checkUserUrlAllowlist(url);
   }
 
   /**
-   * Check if URL matches user-configured whitelist patterns
+   * Check if URL matches user-configured allowlist patterns
    */
-  function checkUserUrlWhitelist(url) {
+  function checkUserUrlAllowlist(url) {
     try {
-      // Get URL whitelist from current config (loaded from storage)
-      if (!window.checkUserConfig?.urlWhitelist) {
+      // Get URL allowlist from current config (loaded from storage)
+      if (!window.checkUserConfig?.urlAllowlist) {
         return false;
       }
 
-      const urlWhitelist = window.checkUserConfig.urlWhitelist;
-      if (!Array.isArray(urlWhitelist) || urlWhitelist.length === 0) {
+      const urlAllowlist = window.checkUserConfig.urlAllowlist;
+      if (!Array.isArray(urlAllowlist) || urlAllowlist.length === 0) {
         return false;
       }
 
-      // Test URL against each whitelist pattern
-      for (const pattern of urlWhitelist) {
+      // Test URL against each allowlist pattern
+      for (const pattern of urlAllowlist) {
         if (!pattern || !pattern.trim()) continue;
 
         try {
@@ -1968,18 +1968,18 @@ if (window.checkExtensionLoaded) {
 
           if (regex.test(url)) {
             logger.log(
-              `✅ URL whitelisted by user pattern "${pattern}": ${url}`
+              `✅ URL allowlisted by user pattern "${pattern}": ${url}`
             );
             return true;
           }
         } catch (error) {
-          logger.warn(`Invalid URL whitelist pattern: ${pattern}`, error);
+          logger.warn(`Invalid URL allowlist pattern: ${pattern}`, error);
         }
       }
 
       return false;
     } catch (error) {
-      logger.warn("Error checking user URL whitelist:", error);
+      logger.warn("Error checking user URL allowlist:", error);
       return false;
     }
   }
@@ -2336,32 +2336,32 @@ if (window.checkExtensionLoaded) {
         } chars content`
       );
 
-      // Load configuration to check protection settings and URL whitelist
+      // Load configuration to check protection settings and URL allowlist
       const config = await new Promise((resolve) => {
         chrome.storage.local.get(["config"], (result) => {
           resolve(result.config || {});
         });
       });
 
-      // Store config globally for URL whitelist checking
+      // Store config globally for URL allowlist checking
       window.checkUserConfig = config;
 
-      // Early exit if URL is in user whitelist (before any other checks)
-      if (checkUserUrlWhitelist(window.location.href)) {
+      // Early exit if URL is in user allowlist (before any other checks)
+      if (checkUserUrlAllowlist(window.location.href)) {
         logger.log(
-          `✅ URL WHITELISTED BY USER - No scanning needed, exiting immediately`
+          `✅ URL ALLOWLISTED BY USER - No scanning needed, exiting immediately`
         );
         logger.log(
-          `📋 URL matches user whitelist pattern: ${window.location.href}`
+          `📋 URL matches user allowlist pattern: ${window.location.href}`
         );
 
-        // Log as legitimate access for whitelisted URLs (only on first run)
+        // Log as legitimate access for allowlisted URLs (only on first run)
         if (!isRerun) {
           logProtectionEvent({
             type: "legitimate_access",
             url: location.href,
             origin: location.origin,
-            reason: "URL matches user-configured whitelist pattern",
+            reason: "URL matches user-configured allowlist pattern",
             redirectTo: null,
             clientId: null,
             clientSuspicious: false,
@@ -2369,7 +2369,7 @@ if (window.checkExtensionLoaded) {
           });
         }
 
-        return; // EXIT IMMEDIATELY - can't be phishing on user-whitelisted URL
+        return; // EXIT IMMEDIATELY - can't be phishing on user-allowlisted URL
       }
 
       // Check if page blocking is disabled

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -252,9 +252,9 @@ export class ConfigManager {
       scanDelay: 100,
       maxScanDepth: 10,
 
-      // Whitelist/Blacklist
-      whitelistedDomains: [],
-      blacklistedDomains: [],
+      // Allow/Deny lists
+      allowlistedDomains: [],
+      denylistedDomains: [],
 
       // Enterprise features
       enterpriseMode: false,


### PR DESCRIPTION
- Adds a new section for the Edge link and also adjusts the Chrome store link to the redirected location now that is it published (saving the world 1 less request at a time).
- In the same spirit I added a trailing slash to the root domain.
- Fixes a case typo in options.js.
- Updates terminology to be more inclusive.