### PR TITLE
Workflow fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,6 @@ name: "🐞 Bug report"
 description: "Report errors or unexpected behaviors for Check"
 title: "[Bug]: " 
 labels:
-  - "unconfirmed-by-user"
   - "bug"
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -3,14 +3,13 @@ description: "Suggest a new feature or improvement"
 title: "[Feature Request]: "
 labels:
   - "enhancement"
-  - "no-priority"
 
 body:
   # Introductory Markdown
   - type: markdown
     attributes:
       value: |
-        **Thank you for suggesting a new feature or improvement for CIPP**
+        **Thank you for suggesting a new feature or improvement for Check!**
 
         Before creating a request, please:
 
@@ -18,9 +17,9 @@ body:
         2. Note that **repeat feature requests** are permitted if a previous request was closed more than 30 days ago.
         3. Consider implementing the feature yourself by reviewing the [contribution guidelines](./CyberDrain/Check/blob/main/CONTRIBUTING.md).
         4. Feature requests that lack sufficient detail or feasibility may be closed at any time.
-        5. **This request will auto-close in 14 days** if no meaningful progress or collaboration occurs.
-        6. If you would like to work on this feature, comment `"I'd like to work on this please!"`
-        7. Any request that is detrimental to security or the product's stability will be closed without notice.
+        5. If you would like to work on this feature, comment `"I'd like to work on this please!"`
+        6. Any request that is detrimental to security or the product's stability will be closed without notice.
+        7. Development is primarily driven by community volunteers. New features may not be implemented immediately or at all, and are at the contributors' discretion.
 
   # Checkboxes for Confirmations
   - type: checkboxes

--- a/.github/workflows/Assign_Issue_Volunteer.yml
+++ b/.github/workflows/Assign_Issue_Volunteer.yml
@@ -1,6 +1,8 @@
 ---
 name: 'Assign Issue to Volunteer'
 on: [issue_comment]  # yamllint disable-line rule:truthy
+permissions:
+  issues: write
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Comment_on_Issues.yml
+++ b/.github/workflows/Comment_on_Issues.yml
@@ -6,7 +6,7 @@ on:
       - labeled
 jobs:
   add-comment_bug:
-    if: github.repository_owner == 'CyberDrain' && github.event.label.name == 'unconfirmed-by-user'
+    if: github.repository_owner == 'CyberDrain' && github.event.label.name == 'bug'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -20,3 +20,18 @@ jobs:
             > I would like to work on this please!
             
             Thank you for helping us maintain the project!
+  add-comment_feature:
+    if: github.repository_owner == 'CyberDrain' && github.event.label.name == 'enhancement'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thank you for suggesting a new feature. If you would like to work on this feature, please comment:
+            > I would like to work on this please!
+            
+            Thank you for helping us improve the project!

--- a/.github/workflows/Label_Issues.yml
+++ b/.github/workflows/Label_Issues.yml
@@ -5,8 +5,8 @@ on:
     types:
       - opened
 jobs:
-  label_issues_bugs:
-    if: github.repository_owner == 'CyberDrain' && contains(github.event.issue.title, 'Bug')
+  label_issues:
+    if: github.repository_owner == 'CyberDrain'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -15,17 +15,5 @@ jobs:
         uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
         with:
           add-labels: 'not-assigned'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-if-assigned: true
-  label_issues_frs:
-    if: github.repository_owner == 'CyberDrain' && contains(github.event.issue.title, 'Feature')
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Label Issues
-        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
-        with:
-          add-labels: 'enhancement, not-assigned'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ignore-if-assigned: true


### PR DESCRIPTION
**Workflow and Automation Improvements**

* Consolidated issue labeling (with `not-assigned`) workflows by merging separate bug and feature request label jobs into a single `label_issues` job, as the conditions were fundamentally the same
* Added explicit `issues: write` permissions to the `Assign_Issue_Volunteer.yml` workflow to ensure proper access for issue assignment automation.
* Updated the `Comment_on_Issues.yml` workflow to trigger bug comments on issues labeled "bug" (instead of "unconfirmed-by-user") and added a new job to comment on enhancement-labeled issues, improving contributor communication for both bug reports and feature requests.

**Issue Template Updates**

* Removed the "unconfirmed-by-user" label from the bug report template to align with the updated workflow logic.
* Improved the feature request template by updating introductory guidance, removing the auto-close warning, clarifying contributor/requestor expectations, and replacing a reference to "CIPP" with "Check" for consistency.