### PR TITLE
Update content script with wake guard logic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Thanks for taking the time to contribute! These guidelines help keep contributio
 Security vulnerabilities should be reported privately. Refer to [SECURITY.md](SECURITY.md) for disclosure instructions instead of opening public issues or pull requests.
 
 ## Pull Request Workflow
-1. Create a topic branch from `main`.
+1. Create a topic branch from `dev`.
 2. Make your changes and commit them following the guidelines above.
 3. Ensure manual tests pass and any ESLint checks you run are clean.
 4. Push your branch and open a pull request describing the changes and test results.

--- a/rules/detection-rules.json
+++ b/rules/detection-rules.json
@@ -30,7 +30,7 @@
     "^https://[^.]*\\.microsoftonline-p\\.com$",
     "^https://[^.]*\\.microsoftazuread-sso\\.com$",
     "^https://[^.]*\\.azureedge\\.net$",
-    "^https://[^.]*\\.bing\\.com$",
+    "^https://[^.]*\\.bing\\.com$"
   ],
   "exclusion_system": {
     "description": "Centralized exclusion system to prevent false positives on legitimate sites",


### PR DESCRIPTION
First draft at a fix for #76  
Important to note, this is untested, and I am not even 100% sure if this is the actual root cause of the issue.

This pull request introduces a new "WakeGuard" feature to the `scripts/content.js` file, which helps prevent unnecessary or premature re-scans when a browser tab becomes visible after being hidden. The changes focus on improving extension performance and reliability by stabilizing DOM analysis after tab wake events. Additionally, there is a minor update to the branch workflow in `CONTRIBUTING.md` and a formatting adjustment in `rules/detection-rules.json`.

WakeGuard and DOM stabilization improvements:

* Added wake guard logic to track when a tab becomes visible, introducing a stabilization window (`WAKE_STABILIZATION_MS`) to delay protection re-runs until the DOM has settled. This includes new state variables (`lastWakeTime`, `wakeGuardActive`, `wakeGuardTimeout`) and event handling for `visibilitychange`.
* Implemented `scheduleWakeGuardRelease` to trigger a protection re-run only after the stabilization period, ensuring that scans are not performed while the DOM is still changing. 
* Modified the main protection logic (`runProtection`) to respect the wake guard state, skipping unnecessary scans if the tab was recently activated and the DOM may still be unstable. Contextual logging was added for better traceability.
* Added a utility function `isNonSuspiciousResult` to help determine when a re-scan is appropriate after a tab wake event.

Other updates:

* Updated the pull request workflow in `CONTRIBUTING.md` to instruct contributors to branch from `dev` instead of `main`. (cough, @bmsimp)
* Minor formatting fix in `rules/detection-rules.json` (no logic change) to align it with main.