### PR TITLE
Fix urlAllowlist registry entries to be in the correct format and Edge pinning in the ADMX

### DIFF
--- a/enterprise/Deploy-Windows-Chrome-and-Edge.ps1
+++ b/enterprise/Deploy-Windows-Chrome-and-Edge.ps1
@@ -59,8 +59,23 @@ function Configure-ExtensionSettings {
     New-ItemProperty -Path $ManagedStorageKey -Name "cippTenantId" -PropertyType String -Value $cippTenantId -Force | Out-Null
     New-ItemProperty -Path $ManagedStorageKey -Name "customRulesUrl" -PropertyType String -Value $customRulesUrl -Force | Out-Null
     New-ItemProperty -Path $ManagedStorageKey -Name "updateInterval" -PropertyType DWord -Value $updateInterval -Force | Out-Null
-    New-ItemProperty -Path $ManagedStorageKey -Name "urlAllowlist" -PropertyType MultiString -Value $urlAllowlist -Force | Out-Null
     New-ItemProperty -Path $ManagedStorageKey -Name "enableDebugLogging" -PropertyType DWord -Value $enableDebugLogging -Force | Out-Null
+
+    # Create and configure URL allow list
+    $urlAllowlistKey = "$ManagedStorageKey\urlAllowlist"
+    if (!(Test-Path $urlAllowlistKey)) {
+        New-Item -Path $urlAllowlistKey -Force | Out-Null
+    }
+
+    # Clear any existing properties
+    Remove-ItemProperty -Path $urlAllowlistKey -Name * -Force | Out-Null
+
+    # Set URL allow list properties with names starting from 1
+    for ($i = 0; $i -lt $urlAllowlist.Count; $i++) {
+        $propertyName = ($i + 1).ToString()
+        $propertyValue = $urlAllowlist[$i]
+        New-ItemProperty -Path $urlAllowlistKey -Name $propertyName -PropertyType String -Value $propertyValue -Force | Out-Null
+    }
 
     # Create and configure custom branding
     $customBrandingKey = "$ManagedStorageKey\customBranding"

--- a/enterprise/admx/Check-Extension.admx
+++ b/enterprise/admx/Check-Extension.admx
@@ -39,9 +39,9 @@
             <string>https://edge.microsoft.com/extensionwebstorebase/v1/crx</string>
           </value>
         </item>
-        <item key="SOFTWARE\Policies\Microsoft\Edge\ExtensionSettings\knepjpocdagponkonnbggpcnhnaikajg" valueName="toolbar_pin">
+        <item key="SOFTWARE\Policies\Microsoft\Edge\ExtensionSettings\knepjpocdagponkonnbggpcnhnaikajg" valueName="toolbar_state">
           <value>
-            <string>force_pinned</string>
+            <string>force_shown</string>
           </value>
         </item>
       </enabledList>
@@ -132,11 +132,11 @@
     </policy>
 
     <!-- URL Allowlist -->
-    <policy name="CheckUrlAllowlist" class="Machine" displayName="$(string.CheckUrlAllowlist)" explainText="$(string.CheckUrlAllowlist_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy" presentation="$(presentation.CheckUrlAllowlist)">
+    <policy name="CheckUrlAllowlist" class="Machine" displayName="$(string.CheckUrlAllowlist)" explainText="$(string.CheckUrlAllowlist_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy\urlAllowlist" presentation="$(presentation.CheckUrlAllowlist)">
       <parentCategory ref="CheckExtensionEdge" />
       <supportedOn ref="SUPPORTED_WIN7" />
       <elements>
-        <list id="UrlAllowlistList" valueName="urlAllowlist" />
+        <list id="UrlAllowlistList" valueName="urlAllowlist" valuePrefix="" />
       </elements>
     </policy>
 
@@ -307,11 +307,11 @@
     </policy>
 
     <!-- URL Allowlist - Chrome -->
-    <policy name="CheckUrlAllowlistChrome" class="Machine" displayName="$(string.CheckUrlAllowlistChrome)" explainText="$(string.CheckUrlAllowlistChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy" presentation="$(presentation.CheckUrlAllowlistChrome)">
+    <policy name="CheckUrlAllowlistChrome" class="Machine" displayName="$(string.CheckUrlAllowlistChrome)" explainText="$(string.CheckUrlAllowlistChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy\urlAllowlist" presentation="$(presentation.CheckUrlAllowlistChrome)">
       <parentCategory ref="CheckExtensionChrome" />
       <supportedOn ref="SUPPORTED_WIN7" />
       <elements>
-        <list id="UrlAllowlistListChrome" valueName="urlAllowlist" />
+        <list id="UrlAllowlistListChrome" valueName="urlAllowlist" valuePrefix="" />
       </elements>
     </policy>
 


### PR DESCRIPTION
- Chrome and Edge won't load the allow list URLs unless they are in a subkey with each URL as a numbered property.
- Also corrects the pinning setting for Edge in the ADMX file.