### PR TITLE
Add support/privacy/about branding URLs

### DIFF
--- a/config/branding.json
+++ b/config/branding.json
@@ -1,7 +1,9 @@
 {
   "companyName": "CyberDrain",
-  "companyURL": "https://cyberdrain.com/",
   "productName": "Check",
+  "supportUrl": "https://support.cyberdrain.com",
+  "privacyPolicyUrl": "https://cyberdrain.com/privacy",
+  "aboutUrl": "",
   "version": "1.1.0",
   "description": "Protect against phishing attacks targeting Microsoft 365 login pages with enterprise-grade detection",
   "branding": {

--- a/config/managed_schema.json
+++ b/config/managed_schema.json
@@ -126,12 +126,6 @@
           "type": "string",
           "default": ""
         },
-		"companyURL": {
-          "title": "Company URL",
-          "description": "Company URL used in the extension",
-          "type": "string",
-          "default": "https://cyberdrain.com/"
-        },
         "productName": {
           "title": "Product Name",
           "description": "Custom name for the extension",
@@ -143,6 +137,27 @@
           "description": "Email address for user support",
           "type": "string",
           "format": "email",
+          "default": ""
+        },
+        "supportUrl": {
+          "title": "Support URL",
+          "description": "URL opened by the popup Support link",
+          "type": "string",
+          "format": "uri",
+          "default": ""
+        },
+        "privacyPolicyUrl": {
+          "title": "Privacy URL",
+          "description": "URL opened by the popup Privacy link",
+          "type": "string",
+          "format": "uri",
+          "default": ""
+        },
+        "aboutUrl": {
+          "title": "About URL",
+          "description": "URL opened by the popup About link",
+          "type": "string",
+          "format": "uri",
           "default": ""
         },
         "primaryColor": {

--- a/docs/settings/branding.md
+++ b/docs/settings/branding.md
@@ -30,9 +30,11 @@ If some settings do not appear on your version, it means your organization's IT 
 You can customize the following properties:
 
 1. **Company Name** - Enter your organization's name. This appears in the extension interface and blocked page messages (displayed as "Protected by \[Company Name]").
-2. **Company URL** - Your company website URL (e.g., `https://yourcompany.com`). Used in extension branding and contact information. _(Firefox: required, Chrome/Edge: optional)_
-3. **Product Name** - What you want to call the extension (like "Contoso Security" instead of "Check"). This replaces the default "Check" branding throughout the interface.
-4. **Support Email** - Where users should go for help. This email address is used in the "Contact Admin" button when phishing sites are blocked.
+2. **Product Name** - What you want to call the extension (like "Contoso Security" instead of "Check"). This replaces the default "Check" branding throughout the interface.
+3. **Support Email** - Where users should go for help. This email address is used in the "Contact Admin" button when phishing sites are blocked.
+4. **Support URL** - URL opened by the popup **Support** link (for example, `https://support.yourcompany.com`).
+5. **Privacy Policy URL** (`privacyPolicyUrl`) - URL opened by the popup **Privacy** link (for example, `https://yourcompany.com/privacy`).
+6. **About URL** (`aboutUrl`) - URL opened by the popup **About** link. Leave empty to use the built-in extension About page.
 
 ## Visual Customization
 
@@ -60,6 +62,9 @@ The branding preview shows you exactly how your customizations will appear to us
    * Logo (upload or provide URL)
    * Primary Color
    * Support Email
+   * Support URL
+   * Privacy Policy URL
+   * About URL
 4. Click "Save"
 
 Your branding will be immediately applied to all components.
@@ -78,7 +83,10 @@ For enterprise deployments using Windows Group Policy:
     "companyName": "Your Company",
     "logoUrl": "https://example.com/logo.png",
     "primaryColor": "#FF5733",
-    "supportEmail": "security@example.com"
+    "supportEmail": "security@example.com",
+    "supportUrl": "https://support.example.com",
+    "privacyPolicyUrl": "https://example.com/privacy",
+    "aboutUrl": "https://example.com/about"
   }
 }
 ```
@@ -106,9 +114,11 @@ For Firefox deployments, configure branding through the `policies.json` file:
         "check@cyberdrain.com": {
           "customBranding": {
             "companyName": "Your Company",
-            "companyURL": "https://yourcompany.com",
             "productName": "Security Extension",
             "supportEmail": "security@example.com",
+            "supportUrl": "https://support.example.com",
+            "privacyPolicyUrl": "https://example.com/privacy",
+            "aboutUrl": "https://example.com/about",
             "primaryColor": "#FF5733",
             "logoUrl": "https://example.com/logo.png"
           }
@@ -137,7 +147,10 @@ For organizations using Microsoft Intune with Chrome/Edge:
     "companyName": "Your Company",
     "logoUrl": "https://example.com/logo.png",
     "primaryColor": "#FF5733",
-    "supportEmail": "security@example.com"
+    "supportEmail": "security@example.com",
+    "supportUrl": "https://support.example.com",
+    "privacyPolicyUrl": "https://example.com/privacy",
+    "aboutUrl": "https://example.com/about"
   }
 }
 ```
@@ -201,7 +214,6 @@ Enterprise policies always take precedence over manual settings.
 
 * Uses extension ID: `check@cyberdrain.com`
 * Configuration is managed through `policies.json` file
-* Supports additional `companyURL` property
 * Policies file location varies by operating system
 
 ### Chrome & Edge
@@ -290,7 +302,10 @@ Logo URL: https://assets.globalmfg.com/security/gmi-logo-48.png
     "productName": "Contoso Defender",
     "logoUrl": "https://contoso.com/assets/logo.png",
     "primaryColor": "#0078D4",
-    "supportEmail": "security@contoso.com"
+    "supportEmail": "security@contoso.com",
+    "supportUrl": "https://support.contoso.com",
+    "privacyPolicyUrl": "https://contoso.com/privacy",
+    "aboutUrl": "https://contoso.com/about"
   }
 }
 ```
@@ -305,11 +320,13 @@ Logo URL: https://assets.globalmfg.com/security/gmi-logo-48.png
         "check@cyberdrain.com": {
           "customBranding": {
             "companyName": "Contoso Corporation",
-            "companyURL": "https://contoso.com",
             "productName": "Contoso Defender",
             "logoUrl": "https://contoso.com/assets/logo.png",
             "primaryColor": "#0078D4",
-            "supportEmail": "security@contoso.com"
+            "supportEmail": "security@contoso.com",
+            "supportUrl": "https://support.contoso.com",
+            "privacyPolicyUrl": "https://contoso.com/privacy",
+            "aboutUrl": "https://contoso.com/about"
           }
         }
       }

--- a/enterprise/Check-Extension-Policy.reg
+++ b/enterprise/Check-Extension-Policy.reg
@@ -25,6 +25,9 @@ Windows Registry Editor Version 5.00
 "companyName"="CyberDrain"
 "productName"="Check"
 "supportEmail"=""
+"supportUrl"=""
+"privacyPolicyUrl"=""
+"aboutUrl"=""
 "primaryColor"="#F77F00"
 "logoUrl"=""
 
@@ -57,6 +60,9 @@ Windows Registry Editor Version 5.00
 "companyName"="CyberDrain"
 "productName"="Check"
 "supportEmail"=""
+"supportUrl"=""
+"privacyPolicyUrl"=""
+"aboutUrl"=""
 "primaryColor"="#F77F00"
 "logoUrl"=""
 

--- a/enterprise/Deploy-Windows-Chrome-and-Edge.ps1
+++ b/enterprise/Deploy-Windows-Chrome-and-Edge.ps1
@@ -31,9 +31,11 @@ $webhookEvents = @() # This will set the "Event Types" to send to the webhook; d
 
 # Custom Branding Settings
 $companyName = "CyberDrain" # This will set the "Company Name" option in the Custom Branding settings; default is "CyberDrain".
-$companyURL = "https://cyberdrain.com" # This will set the Company URL option in the Custom Branding settings; default is "https://cyberdrain.com"; Must include the protocol (e.g., https://).
 $productName = "Check - Phishing Protection" # This will set the "Product Name" option in the Custom Branding settings; default is "Check - Phishing Protection".
 $supportEmail = "" # This will set the "Support Email" option in the Custom Branding settings; default is blank.
+$supportUrl = "" # This will set the "Support URL" option in the Custom Branding settings; default is blank.
+$privacyPolicyUrl = "" # This will set the "Privacy URL" option in the Custom Branding settings; default is blank.
+$aboutUrl = "" # This will set the "About URL" option in the Custom Branding settings; default is blank.
 $primaryColor = "#F77F00" # This will set the "Primary Color" option in the Custom Branding settings; default is "#F77F00"; must be a valid hex color code (e.g., #FFFFFF).
 $logoUrl = "" # This will set the "Logo URL" option in the Custom Branding settings; default is blank. Must be a valid URL including the protocol (e.g., https://example.com/logo.png); protocol must be https; recommended size is 48x48 pixels with a maximum of 128x128.
 
@@ -90,9 +92,11 @@ function Configure-ExtensionSettings {
 
     # Set custom branding settings
     New-ItemProperty -Path $customBrandingKey -Name "companyName" -PropertyType String -Value $companyName -Force | Out-Null
-    New-ItemProperty -Path $customBrandingKey -Name "companyURL" -PropertyType String -Value $companyURL -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "productName" -PropertyType String -Value $productName -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "supportEmail" -PropertyType String -Value $supportEmail -Force | Out-Null
+    New-ItemProperty -Path $customBrandingKey -Name "supportUrl" -PropertyType String -Value $supportUrl -Force | Out-Null
+    New-ItemProperty -Path $customBrandingKey -Name "privacyPolicyUrl" -PropertyType String -Value $privacyPolicyUrl -Force | Out-Null
+    New-ItemProperty -Path $customBrandingKey -Name "aboutUrl" -PropertyType String -Value $aboutUrl -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "primaryColor" -PropertyType String -Value $primaryColor -Force | Out-Null
     New-ItemProperty -Path $customBrandingKey -Name "logoUrl" -PropertyType String -Value $logoUrl -Force | Out-Null
 

--- a/enterprise/Remove-Windows-Chrome-and-Edge.ps1
+++ b/enterprise/Remove-Windows-Chrome-and-Edge.ps1
@@ -63,9 +63,11 @@ function Remove-ExtensionSettings {
         if (Test-Path $customBrandingKey) {
             $brandingPropertiesToRemove = @(
                 "companyName",
-                "companyURL",
                 "productName",
                 "supportEmail",
+                "supportUrl",
+                "privacyPolicyUrl",
+                "aboutUrl",
                 "primaryColor",
                 "logoUrl"
             )

--- a/enterprise/Test-Extension-Policy.ps1
+++ b/enterprise/Test-Extension-Policy.ps1
@@ -26,7 +26,6 @@ $testConfig = @{
 # Custom branding test values
 $testBranding = @{
   companyName = "Test Company"
-  companyURL = "https://example.com"
   productName = "Test Product"
   supportEmail = "test@example.com"
   primaryColor = "#FF6B00"

--- a/enterprise/admx/Check-Extension.admx
+++ b/enterprise/admx/Check-Extension.admx
@@ -176,6 +176,33 @@
       </elements>
     </policy>
 
+    <!-- Support URL -->
+    <policy name="CheckSupportUrl" class="Machine" displayName="$(string.CheckSupportUrl)" explainText="$(string.CheckSupportUrl_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy\customBranding" presentation="$(presentation.CheckSupportUrl)">
+      <parentCategory ref="CheckExtensionEdge" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="SupportUrl" valueName="supportUrl" />
+      </elements>
+    </policy>
+
+    <!-- Privacy URL -->
+    <policy name="CheckPrivacyPolicyUrl" class="Machine" displayName="$(string.CheckPrivacyPolicyUrl)" explainText="$(string.CheckPrivacyPolicyUrl_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy\customBranding" presentation="$(presentation.CheckPrivacyPolicyUrl)">
+      <parentCategory ref="CheckExtensionEdge" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="PrivacyPolicyUrl" valueName="privacyPolicyUrl" />
+      </elements>
+    </policy>
+
+    <!-- About URL -->
+    <policy name="CheckAboutUrl" class="Machine" displayName="$(string.CheckAboutUrl)" explainText="$(string.CheckAboutUrl_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy\customBranding" presentation="$(presentation.CheckAboutUrl)">
+      <parentCategory ref="CheckExtensionEdge" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="AboutUrl" valueName="aboutUrl" />
+      </elements>
+    </policy>
+
     <!-- Primary Color -->
     <policy name="CheckPrimaryColor" class="Machine" displayName="$(string.CheckPrimaryColor)" explainText="$(string.CheckPrimaryColor_Explain)" key="SOFTWARE\Policies\Microsoft\Edge\3rdparty\extensions\knepjpocdagponkonnbggpcnhnaikajg\policy\customBranding" presentation="$(presentation.CheckPrimaryColor)">
       <parentCategory ref="CheckExtensionEdge" />
@@ -357,6 +384,33 @@
       <supportedOn ref="SUPPORTED_WIN7" />
       <elements>
         <text id="SupportEmailChrome" valueName="supportEmail" />
+      </elements>
+    </policy>
+
+    <!-- Support URL - Chrome -->
+    <policy name="CheckSupportUrlChrome" class="Machine" displayName="$(string.CheckSupportUrlChrome)" explainText="$(string.CheckSupportUrlChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy\customBranding" presentation="$(presentation.CheckSupportUrlChrome)">
+      <parentCategory ref="CheckExtensionChrome" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="SupportUrlChrome" valueName="supportUrl" />
+      </elements>
+    </policy>
+
+    <!-- Privacy URL - Chrome -->
+    <policy name="CheckPrivacyPolicyUrlChrome" class="Machine" displayName="$(string.CheckPrivacyPolicyUrlChrome)" explainText="$(string.CheckPrivacyPolicyUrlChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy\customBranding" presentation="$(presentation.CheckPrivacyPolicyUrlChrome)">
+      <parentCategory ref="CheckExtensionChrome" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="PrivacyPolicyUrlChrome" valueName="privacyPolicyUrl" />
+      </elements>
+    </policy>
+
+    <!-- About URL - Chrome -->
+    <policy name="CheckAboutUrlChrome" class="Machine" displayName="$(string.CheckAboutUrlChrome)" explainText="$(string.CheckAboutUrlChrome_Explain)" key="SOFTWARE\Policies\Google\Chrome\3rdparty\extensions\benimdeioplgkhanklclahllklceahbe\policy\customBranding" presentation="$(presentation.CheckAboutUrlChrome)">
+      <parentCategory ref="CheckExtensionChrome" />
+      <supportedOn ref="SUPPORTED_WIN7" />
+      <elements>
+        <text id="AboutUrlChrome" valueName="aboutUrl" />
       </elements>
     </policy>
 

--- a/enterprise/admx/en-US/Check-Extension.adml
+++ b/enterprise/admx/en-US/Check-Extension.adml
@@ -181,15 +181,6 @@
                 
                 The company name appears in the extension popup and settings pages.
             </string>
-            <!-- Company URL -->
-            <string id="CheckCompanyUrl">Company URL</string>
-            <string id="CheckCompanyUrl_Explain">
-                This policy specifies the company URL used in the extension for branding and navigation purposes.
-                
-                Example: https://contoso.com
-                
-                The company URL is used for linking back to the company website from the extension interface.
-            </string>
             <!-- Product Name -->
             <string id="CheckProductName">Product name</string>
             <string id="CheckProductName_Explain">
@@ -207,6 +198,27 @@
                 Example: security@contoso.com
                 
                 This email address is displayed in the extension interface and help documentation.
+            </string>
+            <!-- Support URL -->
+            <string id="CheckSupportUrl">Support URL</string>
+            <string id="CheckSupportUrl_Explain">
+                This policy specifies the support URL opened by the extension Support link.
+                
+                Example: https://support.contoso.com
+            </string>
+            <!-- Privacy URL -->
+            <string id="CheckPrivacyPolicyUrl">Privacy URL</string>
+            <string id="CheckPrivacyPolicyUrl_Explain">
+                This policy specifies the privacy policy URL opened by the extension Privacy link.
+                
+                Example: https://contoso.com/privacy
+            </string>
+            <!-- About URL -->
+            <string id="CheckAboutUrl">About URL</string>
+            <string id="CheckAboutUrl_Explain">
+                This policy specifies the about URL opened by the extension About link.
+                
+                Example: https://contoso.com/about
             </string>
             <!-- Primary Color -->
             <string id="CheckPrimaryColor">Primary theme color</string>
@@ -330,15 +342,6 @@
                 
                 The company name appears in the extension popup and settings pages.
             </string>
-            <!-- Company URL - Chrome -->
-            <string id="CheckCompanyUrlChrome">Company URL (Chrome)</string>
-            <string id="CheckCompanyUrlChrome_Explain">
-                This policy specifies the company URL used in the extension for branding and navigation purposes in Google Chrome.
-                
-                Example: https://contoso.com
-                
-                The company URL is used for linking back to the company website from the extension interface.
-            </string>
             <!-- Product Name - Chrome -->
             <string id="CheckProductNameChrome">Product name (Chrome)</string>
             <string id="CheckProductNameChrome_Explain">
@@ -356,6 +359,27 @@
                 Example: security@contoso.com
                 
                 This email address is displayed in the extension interface and help documentation.
+            </string>
+            <!-- Support URL - Chrome -->
+            <string id="CheckSupportUrlChrome">Support URL (Chrome)</string>
+            <string id="CheckSupportUrlChrome_Explain">
+                This policy specifies the support URL opened by the extension Support link in Google Chrome.
+                
+                Example: https://support.contoso.com
+            </string>
+            <!-- Privacy URL - Chrome -->
+            <string id="CheckPrivacyPolicyUrlChrome">Privacy URL (Chrome)</string>
+            <string id="CheckPrivacyPolicyUrlChrome_Explain">
+                This policy specifies the privacy policy URL opened by the extension Privacy link in Google Chrome.
+                
+                Example: https://contoso.com/privacy
+            </string>
+            <!-- About URL - Chrome -->
+            <string id="CheckAboutUrlChrome">About URL (Chrome)</string>
+            <string id="CheckAboutUrlChrome_Explain">
+                This policy specifies the about URL opened by the extension About link in Google Chrome.
+                
+                Example: https://contoso.com/about
             </string>
             <!-- Primary Color - Chrome -->
             <string id="CheckPrimaryColorChrome">Primary theme color (Chrome)</string>
@@ -409,11 +433,6 @@
                     <label>Company Name:</label>
                 </textBox>
             </presentation>
-            <presentation id="CheckCompanyUrl">
-                <textBox refId="CompanyUrl">
-                    <label>Company URL:</label>
-                </textBox>
-            </presentation>
             <presentation id="CheckProductName">
                 <textBox refId="ProductName">
                     <label>Product Name:</label>
@@ -422,6 +441,21 @@
             <presentation id="CheckSupportEmail">
                 <textBox refId="SupportEmail">
                     <label>Support Email:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckSupportUrl">
+                <textBox refId="SupportUrl">
+                    <label>Support URL:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckPrivacyPolicyUrl">
+                <textBox refId="PrivacyPolicyUrl">
+                    <label>Privacy URL:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckAboutUrl">
+                <textBox refId="AboutUrl">
+                    <label>About URL:</label>
                 </textBox>
             </presentation>
             <presentation id="CheckPrimaryColor">
@@ -458,11 +492,6 @@
                     <label>Company Name:</label>
                 </textBox>
             </presentation>
-            <presentation id="CheckCompanyUrlChrome">
-                <textBox refId="CompanyUrlChrome">
-                    <label>Company URL:</label>
-                </textBox>
-            </presentation>
             <presentation id="CheckProductNameChrome">
                 <textBox refId="ProductNameChrome">
                     <label>Product Name:</label>
@@ -471,6 +500,21 @@
             <presentation id="CheckSupportEmailChrome">
                 <textBox refId="SupportEmailChrome">
                     <label>Support Email:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckSupportUrlChrome">
+                <textBox refId="SupportUrlChrome">
+                    <label>Support URL:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckPrivacyPolicyUrlChrome">
+                <textBox refId="PrivacyPolicyUrlChrome">
+                    <label>Privacy URL:</label>
+                </textBox>
+            </presentation>
+            <presentation id="CheckAboutUrlChrome">
+                <textBox refId="AboutUrlChrome">
+                    <label>About URL:</label>
                 </textBox>
             </presentation>
             <presentation id="CheckPrimaryColorChrome">

--- a/enterprise/firefox/policies.json
+++ b/enterprise/firefox/policies.json
@@ -31,9 +31,11 @@
           "enableDebugLogging": false,
           "customBranding": {
             "companyName": "",
-            "companyURL": "https://cyberdrain.com/",
             "productName": "",
             "supportEmail": "",
+            "supportUrl": "",
+            "privacyPolicyUrl": "",
+            "aboutUrl": "",
             "primaryColor": "#F77F00",
             "logoUrl": ""
           },

--- a/enterprise/macos-linux/chrome-managed-policy.json
+++ b/enterprise/macos-linux/chrome-managed-policy.json
@@ -22,6 +22,9 @@
                     "companyName": "",
                     "productName": "",
                     "supportEmail": "",
+                    "supportUrl": "",
+                    "privacyPolicyUrl": "",
+                    "aboutUrl": "",
                     "primaryColor": "#F77F00",
                     "logoUrl": ""
                 },

--- a/enterprise/macos-linux/edge-managed-policy.json
+++ b/enterprise/macos-linux/edge-managed-policy.json
@@ -22,6 +22,9 @@
                     "companyName": "",
                     "productName": "",
                     "supportEmail": "",
+                    "supportUrl": "",
+                    "privacyPolicyUrl": "",
+                    "aboutUrl": "",
                     "primaryColor": "#F77F00",
                     "logoUrl": ""
                 },

--- a/options/options.html
+++ b/options/options.html
@@ -384,14 +384,6 @@
 
                         <div class="setting-item">
                             <label class="setting-label">
-                                Company URL
-                                <input type="url" id="companyURL" class="setting-input" placeholder="https://yourcompany.com">
-                            </label>
-                            <p class="setting-description">Your company website URL</p>
-                        </div>
-
-                        <div class="setting-item">
-                            <label class="setting-label">
                                 Product Name
                                 <input type="text" id="productName" class="setting-input" placeholder="Custom Extension Name">
                             </label>
@@ -404,6 +396,30 @@
                                 <input type="email" id="supportEmail" class="setting-input" placeholder="support@yourcompany.com">
                             </label>
                             <p class="setting-description">Email address for user support</p>
+                        </div>
+
+                        <div class="setting-item">
+                            <label class="setting-label">
+                                Support URL
+                                <input type="url" id="supportUrl" class="setting-input" placeholder="https://support.yourcompany.com">
+                            </label>
+                            <p class="setting-description">URL opened by the popup Support button</p>
+                        </div>
+
+                        <div class="setting-item">
+                            <label class="setting-label">
+                                Privacy URL
+                                <input type="url" id="privacyPolicyUrl" class="setting-input" placeholder="https://yourcompany.com/privacy">
+                            </label>
+                            <p class="setting-description">URL opened by the popup Privacy button</p>
+                        </div>
+
+                        <div class="setting-item">
+                            <label class="setting-label">
+                                About URL
+                                <input type="url" id="aboutUrl" class="setting-input" placeholder="https://yourcompany.com/about">
+                            </label>
+                            <p class="setting-description">URL opened by the popup About button (leave empty to use extension About page)</p>
                         </div>
                     </div>
 

--- a/options/options.js
+++ b/options/options.js
@@ -95,9 +95,11 @@ class CheckOptions {
 
     // Branding
     this.elements.companyName = document.getElementById("companyName");
-    this.elements.companyURL = document.getElementById("companyURL");
     this.elements.productName = document.getElementById("productName");
     this.elements.supportEmail = document.getElementById("supportEmail");
+    this.elements.supportUrl = document.getElementById("supportUrl");
+    this.elements.privacyPolicyUrl = document.getElementById("privacyPolicyUrl");
+    this.elements.aboutUrl = document.getElementById("aboutUrl");
     this.elements.primaryColor = document.getElementById("primaryColor");
     this.elements.logoUrl = document.getElementById("logoUrl");
     this.elements.brandingPreview = document.getElementById("brandingPreview");
@@ -185,8 +187,10 @@ class CheckOptions {
     // Branding preview updates
     const brandingInputs = [
       this.elements.companyName,
-      this.elements.companyURL,
       this.elements.productName,
+      this.elements.supportUrl,
+      this.elements.privacyPolicyUrl,
+      this.elements.aboutUrl,
       this.elements.primaryColor,
       this.elements.logoUrl,
     ];
@@ -476,8 +480,10 @@ class CheckOptions {
       console.warn("Options: Using fallback branding configuration");
       this.brandingConfig = {
         companyName: "CyberDrain",
-    companyURL: "https://cyberdrain.com/",
         productName: "Check",
+        supportUrl: "https://support.cyberdrain.com",
+        privacyPolicyUrl: "https://cyberdrain.com/privacy",
+        aboutUrl: "",
         primaryColor: "#F77F00",
         logoUrl: "images/icon48.png",
       };
@@ -485,8 +491,10 @@ class CheckOptions {
       console.error("Error loading branding configuration:", error);
       this.brandingConfig = {
         companyName: "CyberDrain",
-		    companyURL: "https://cyberdrain.com/",
         productName: "Check",
+        supportUrl: "https://support.cyberdrain.com",
+        privacyPolicyUrl: "https://cyberdrain.com/privacy",
+        aboutUrl: "",
         primaryColor: "#F77F00",
         logoUrl: "images/icon48.png",
       };
@@ -1011,9 +1019,12 @@ class CheckOptions {
 
     // Branding settings
     this.elements.companyName.value = this.brandingConfig?.companyName || "";
-    this.elements.companyURL.value = this.brandingConfig?.companyURL || "";
     this.elements.productName.value = this.brandingConfig?.productName || "";
     this.elements.supportEmail.value = this.brandingConfig?.supportEmail || "";
+    this.elements.supportUrl.value = this.brandingConfig?.supportUrl || "";
+    this.elements.privacyPolicyUrl.value =
+      this.brandingConfig?.privacyPolicyUrl || "";
+    this.elements.aboutUrl.value = this.brandingConfig?.aboutUrl || "";
     this.elements.primaryColor.value =
     this.brandingConfig?.primaryColor || "#F77F00";
     this.elements.logoUrl.value = this.brandingConfig?.logoUrl || "";
@@ -1339,9 +1350,11 @@ class CheckOptions {
   gatherBrandingData() {
     return {
       companyName: this.elements.companyName.value,
-      companyURL: this.elements.companyURL.value,
       productName: this.elements.productName.value,
       supportEmail: this.elements.supportEmail.value,
+      supportUrl: this.elements.supportUrl.value,
+      privacyPolicyUrl: this.elements.privacyPolicyUrl.value,
+      aboutUrl: this.elements.aboutUrl.value,
       primaryColor: this.elements.primaryColor.value,
       logoUrl: this.elements.logoUrl.value,
     };
@@ -2457,8 +2470,10 @@ class CheckOptions {
           // Custom branding (matches managed_schema.json structure)
           customBranding: {
             companyName: "CyberDrain",
-            companyURL: "https://cyberdrain.com/",
             productName: "Check Enterprise",
+            supportUrl: "https://support.cyberdrain.com",
+            privacyPolicyUrl: "https://cyberdrain.com/privacy",
+            aboutUrl: "",
             primaryColor: "#F77F00",
             logoUrl:
               "https://cyberdrain.com/images/favicon_hu_20e77b0e20e363e.png",
@@ -2598,9 +2613,11 @@ class CheckOptions {
       // Note: enableDeveloperConsoleLogging is excluded - should remain available for debugging
       // Branding fields (if customBranding policy is present)
       companyName: this.elements.companyName,
-      companyURL: this.elements.companyURL,
       productName: this.elements.productName,
       supportEmail: this.elements.supportEmail,
+      supportUrl: this.elements.supportUrl,
+      privacyPolicyUrl: this.elements.privacyPolicyUrl,
+      aboutUrl: this.elements.aboutUrl,
       primaryColor: this.elements.primaryColor,
       logoUrl: this.elements.logoUrl,
     };
@@ -3249,10 +3266,6 @@ class CheckOptions {
   }
 
   updateBrandingPreview() {
-    const companyName =
-      this.elements.companyName.value || this.brandingConfig.companyName;
-    const companyURL =
-      this.elements.companyURL.value || this.brandingConfig.companyURL;
     const productName =
       this.elements.productName.value || this.brandingConfig.productName;
     const primaryColor =

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -220,7 +220,7 @@
           <a href="#" id="aboutLink" class="footer-link">About</a>
         </div>
         <div class="company-branding" id="companyBranding">
-          <span class="company-name" id="companyName"><a href="#" id="companyLink" class="footer-link">CyberDrain</a></span>
+          <span class="company-name" id="companyName">CyberDrain</span>
         </div>
       </footer>
     </div>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -67,7 +67,6 @@ class CheckPopup {
     this.elements.aboutLink = document.getElementById("aboutLink");
     this.elements.companyBranding = document.getElementById("companyBranding");
     this.elements.companyName = document.getElementById("companyName");
-    this.elements.companyLink = document.getElementById("companyLink");
 
     // Debug section
     this.elements.debugSection = document.getElementById("debugSection");
@@ -143,9 +142,6 @@ class CheckPopup {
     );
     this.elements.aboutLink.addEventListener("click", (e) =>
       this.handleFooterLink(e, "about")
-    );
-    this.elements.companyLink.addEventListener("click", (e) =>
-      this.handleFooterLink(e, "company")
     );
 
     // Notification close listener
@@ -384,22 +380,22 @@ class CheckPopup {
       console.warn("Popup: Using fallback branding configuration");
       this.brandingConfig = {
         companyName: "CyberDrain",
-        companyURL: "https://cyberdrain.com/",
         productName: "Check",
         logoUrl: "images/icon32.png",
         supportUrl: "https://support.cyberdrain.com",
         privacyPolicyUrl: "https://cyberdrain.com/privacy",
+        aboutUrl: "",
         primaryColor: "#F77F00",
       };
     } catch (error) {
       console.error("Error loading branding configuration:", error);
       this.brandingConfig = {
         companyName: "CyberDrain",
-        companyURL: "https://cyberdrain.com/",
         productName: "Check",
         logoUrl: "images/icon32.png",
         supportUrl: "https://support.cyberdrain.com",
         privacyPolicyUrl: "https://cyberdrain.com/privacy",
+        aboutUrl: "",
         primaryColor: "#F77F00",
       };
     }
@@ -449,6 +445,9 @@ class CheckPopup {
     }
     if (this.brandingConfig.privacyPolicyUrl) {
       this.elements.privacyLink.href = this.brandingConfig.privacyPolicyUrl;
+    }
+    if (this.brandingConfig.aboutUrl) {
+      this.elements.aboutLink.href = this.brandingConfig.aboutUrl;
     }
 
     // Apply primary color if available
@@ -1093,10 +1092,9 @@ class CheckPopup {
         url = this.brandingConfig.privacyPolicyUrl;
         break;
       case "about":
-        url = chrome.runtime.getURL("options/options.html#about");
-        break;
-      case "company":
-        url = this.brandingConfig.companyURL;
+        url =
+          this.brandingConfig.aboutUrl ||
+          chrome.runtime.getURL("options/options.html#about");
         break;
     }
 

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -117,6 +117,9 @@ export class ConfigManager {
           customBranding: {
             companyName: "CyberDrain",
             productName: "Check Enterprise",
+            supportUrl: "https://support.cyberdrain.com",
+            privacyPolicyUrl: "https://cyberdrain.com/privacy",
+            aboutUrl: "",
             primaryColor: "#F77F00",
             logoUrl:
               "https://cyberdrain.com/images/favicon_hu_20e77b0e20e363e.png",
@@ -333,6 +336,7 @@ export class ConfigManager {
       supportEmail: "support@check.com",
       supportUrl: "https://support.check.com",
       privacyPolicyUrl: "https://check.com/privacy",
+      aboutUrl: "",
       termsOfServiceUrl: "https://check.com/terms",
 
       // Customizable text
@@ -462,8 +466,12 @@ export class ConfigManager {
       await this.loadConfig();
     }
 
-    // Start with the base branding config
-    let finalBranding = await this.getBrandingConfig();
+    // Start with defaults to ensure required branding links are always available
+    const defaultBranding = this.getDefaultBrandingConfig();
+    let finalBranding = {
+      ...defaultBranding,
+      ...(await this.getBrandingConfig()),
+    };
 
     // If enterprise has custom branding, merge it in (takes precedence)
     if (this.enterpriseConfig && this.enterpriseConfig.customBranding) {
@@ -478,6 +486,11 @@ export class ConfigManager {
     const currentConfig = await this.getConfig();
     if (currentConfig.genericWebhook) {
       finalBranding.genericWebhook = currentConfig.genericWebhook;
+    }
+
+    // Derive support URL when only partial branding is configured
+    if (!finalBranding.supportUrl && finalBranding.supportEmail) {
+      finalBranding.supportUrl = `mailto:${finalBranding.supportEmail}`;
     }
 
     return finalBranding;

--- a/tests/config-persistence.test.js
+++ b/tests/config-persistence.test.js
@@ -235,3 +235,50 @@ test('ConfigManager - merge precedence', async (t) => {
   delete global.fetch;
   teardownGlobalChrome();
 });
+
+test('ConfigManager - branding links for manual and enterprise config', async (t) => {
+  const chromeMock = setupGlobalChrome();
+
+  global.fetch = async () => ({
+    ok: false,
+    status: 404
+  });
+
+  const { ConfigManager } = await import('../scripts/modules/config-manager.js');
+
+  await t.test('should honor explicit support/privacy/about URLs from enterprise custom branding', async () => {
+    chromeMock.storage.managed.set({
+      customBranding: {
+        supportUrl: 'https://enterprise.example/support',
+        privacyPolicyUrl: 'https://enterprise.example/privacy',
+        aboutUrl: 'https://enterprise.example/about'
+      }
+    });
+
+    const configManager = new ConfigManager();
+    const branding = await configManager.getFinalBrandingConfig();
+
+    assert.strictEqual(branding.supportUrl, 'https://enterprise.example/support');
+    assert.strictEqual(branding.privacyPolicyUrl, 'https://enterprise.example/privacy');
+    assert.strictEqual(branding.aboutUrl, 'https://enterprise.example/about');
+  });
+
+  await t.test('should derive support link from supportEmail when URLs are not set', async () => {
+    await chromeMock.storage.local.set({
+      brandingConfig: {
+        supportEmail: 'help@manual.example'
+      }
+    });
+
+    const configManager = new ConfigManager();
+    const branding = await configManager.getFinalBrandingConfig();
+    const defaultBranding = configManager.getDefaultBrandingConfig();
+
+    assert.strictEqual(branding.supportUrl, 'mailto:help@manual.example');
+    assert.strictEqual(branding.privacyPolicyUrl, defaultBranding.privacyPolicyUrl);
+    assert.strictEqual(branding.aboutUrl, defaultBranding.aboutUrl);
+  });
+
+  delete global.fetch;
+  teardownGlobalChrome();
+});


### PR DESCRIPTION
Introduce supportUrl, privacyPolicyUrl and aboutUrl branding properties across the project. Updates include managed schema, default configs, enterprise policy templates (REG/PS/ADMX/ADML/JSON), options and popup UI/JS, config manager merging logic (including deriving supportUrl from supportEmail when missing), and tests covering branding link behavior. Also removes the legacy companyURL field from many places and updates docs to show the new properties and examples.