### PR TITLE
fix: Refine domain squatting actions and enhance URL allowlist matching

### DIFF
--- a/docs/features/domain-squatting-detection.md
+++ b/docs/features/domain-squatting-detection.md
@@ -92,8 +92,8 @@ Check has an **"Enable Page Blocking"** setting in the extension options that co
 
 - **Page Blocking Enabled** + **Action: "block"** = Page is completely blocked with full-page warning
 - **Page Blocking Enabled** + **Action: "warn"** = Warning banner shown, page remains accessible
-- **Action: "log"** = Detection is recorded in Activity Logs and sent to reporting and webhooks only. No banner and no block are shown to the user, regardless of the Page Blocking setting.
-- **Page Blocking Disabled** = Never blocks. A `block` or `warn` action shows a warning banner instead; a `log` action stays silent.
+- **Action: "log"** = Detection is recorded in Activity Logs and (if configured) sent to reporting and webhooks. No banner and no block are shown to the user, regardless of the Page Blocking setting.
+- **Page Blocking Disabled** = Never blocks. If **Show Notifications** is enabled, a `block` or `warn` action shows a warning banner instead; a `log` action stays silent.
 
 This gives you control over whether you want aggressive blocking, visible warnings, or silent monitoring for suspicious domains.
 

--- a/docs/features/domain-squatting-detection.md
+++ b/docs/features/domain-squatting-detection.md
@@ -88,13 +88,14 @@ You don't need to do anything - the protection works automatically in the backgr
 
 ### Page Blocking Control
 
-Check has an **"Enable Page Blocking"** setting in the extension options that controls how suspicious pages are handled:
+Check has an **"Enable Page Blocking"** setting in the extension options that controls how suspicious pages are handled. The detection **Action** can be one of three values: `block`, `warn`, or `log`.
 
 - **Page Blocking Enabled** + **Action: "block"** = Page is completely blocked with full-page warning
 - **Page Blocking Enabled** + **Action: "warn"** = Warning banner shown, page remains accessible
-- **Page Blocking Disabled** = Warning banner shown regardless of action setting (never blocks)
+- **Action: "log"** = Detection is recorded in Activity Logs and sent to reporting and webhooks only. No banner and no block are shown to the user, regardless of the Page Blocking setting.
+- **Page Blocking Disabled** = Never blocks. A `block` or `warn` action shows a warning banner instead; a `log` action stays silent.
 
-This gives you control over whether you want aggressive blocking or just warnings for suspicious domains.
+This gives you control over whether you want aggressive blocking, visible warnings, or silent monitoring for suspicious domains.
 
 ### For Advanced Users and IT Departments
 
@@ -109,7 +110,7 @@ Edit your `rules/detection-rules.json` file to customize:
 {
   "domain_squatting": {
     "enabled": false,  // Turn detection on/off (default: false)
-    "action": "block" // Action when detected: "block" or "warn"
+    "action": "block" // Action when detected: "block", "warn", or "log"
   }
 }
 ```
@@ -118,7 +119,7 @@ Edit your `rules/detection-rules.json` file to customize:
 ```json
 {
   "domain_squatting": {
-    "action": "block"  // "block" = full page block, "warn" = banner only
+    "action": "block"  // "block" = full page block, "warn" = banner only, "log" = silent, telemetry only
   }
 }
 ```

--- a/options/options.js
+++ b/options/options.js
@@ -1371,9 +1371,12 @@ class CheckOptions {
     if (!escaped.startsWith('^')) {
       escaped = '^' + escaped;
     }
-    // Add end anchor if pattern doesn't end with wildcard
+    // Add end anchor if pattern doesn't end with wildcard. Tolerate an optional
+    // trailing path, query, or fragment so a host or root URL pattern (with or
+    // without a trailing slash) also matches deep links such as https://host/path.
+    // Kept in sync with the copy in scripts/content.js.
     if (!pattern.endsWith('*') && !escaped.endsWith('.*')) {
-      escaped = escaped + '$';
+      escaped = escaped.replace(/\/$/, '') + '(?:[/?#].*)?$';
     }
     return escaped;
   }

--- a/options/options.js
+++ b/options/options.js
@@ -1371,12 +1371,19 @@ class CheckOptions {
     if (!escaped.startsWith('^')) {
       escaped = '^' + escaped;
     }
-    // Add end anchor if pattern doesn't end with wildcard. Tolerate an optional
-    // trailing path, query, or fragment so a host or root URL pattern (with or
-    // without a trailing slash) also matches deep links such as https://host/path.
-    // Kept in sync with the copy in scripts/content.js.
+    // Add the end anchor if the pattern does not already end with a wildcard.
+    // Only a host or root URL pattern (no path beyond an optional single
+    // trailing slash) gets the tolerant trailing matcher, so patterns that
+    // include an explicit path stay exact matches and allowlist entries are
+    // not silently broadened into prefix matches. Kept in sync with the copy
+    // in scripts/content.js.
     if (!pattern.endsWith('*') && !escaped.endsWith('.*')) {
-      escaped = escaped.replace(/\/$/, '') + '(?:[/?#].*)?$';
+      const afterScheme = pattern.replace(/^https?:\/\//i, '');
+      const firstSlash = afterScheme.indexOf('/');
+      const isHostOrRoot = firstSlash === -1 || firstSlash === afterScheme.length - 1;
+      escaped = isHostOrRoot
+        ? escaped.replace(/\/$/, '') + '(?:[/?#].*)?$'
+        : escaped + '$';
     }
     return escaped;
   }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -3411,15 +3411,25 @@ if (window.checkExtensionLoaded) {
       escaped = "^" + escaped;
     }
 
-    // Add end anchor if pattern doesn't end with wildcard. Tolerate an
-    // optional trailing path, query, or fragment so that allowlisting a host
-    // or a root URL (with or without a trailing slash) also matches deep
-    // links such as https://host/path. A single trailing slash in the pattern
-    // is normalized so it does not force an exact match on the bare root URL.
-    // Suffix tricks (for example https://host.evil.com/) still do not match,
+    // Add the end anchor if the pattern does not already end with a wildcard.
+    //
+    // Only a host or root URL pattern (no path segment beyond an optional
+    // single trailing slash) is given the tolerant trailing matcher, so that
+    // allowlisting a host or root URL also matches deep links such as
+    // https://host/path. A pattern that includes an explicit path stays an
+    // exact match, so allowlist entries are not silently broadened into prefix
+    // matches (for example "https://host/safe" must not also allow
+    // "https://host/safe/anything"). Suffix tricks such as
+    // "https://host.evil.com/" still do not match a "https://host/" entry,
     // because the tolerated remainder must begin with /, ?, or #.
     if (!pattern.endsWith("*") && !escaped.endsWith(".*")) {
-      escaped = escaped.replace(/\/$/, "") + "(?:[/?#].*)?$";
+      const afterScheme = pattern.replace(/^https?:\/\//i, "");
+      const firstSlash = afterScheme.indexOf("/");
+      const isHostOrRoot =
+        firstSlash === -1 || firstSlash === afterScheme.length - 1;
+      escaped = isHostOrRoot
+        ? escaped.replace(/\/$/, "") + "(?:[/?#].*)?$"
+        : escaped + "$";
     }
 
     return escaped;

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -4247,19 +4247,29 @@ if (window.checkExtensionLoaded) {
           
           // Check if notifications should be shown
           const showNotifications = config.showNotifications !== false;
-          
-          // Determine if we should block the page
-          // Requires: 1) enablePageBlocking is ON, 2) domain_squatting action is "block"
+
+          // Resolve the effective action as a real three-state value:
+          // 'block' | 'warn' | 'log'. Previously this only checked for
+          // 'block', which collapsed 'log' into 'warn' (banner + "warned").
+          // Semantics: warn logs telemetry AND shows a banner; log logs
+          // telemetry only and shows nothing to the user.
+          const squattingAction = squattingData.action || 'warn';
           logger.debug(`  enablePageBlocking: ${config.enablePageBlocking}`);
           logger.debug(`  squattingData.action: ${squattingData.action}`);
-          const shouldBlock = squattingData.action === 'block' && 
+          const shouldBlock = squattingAction === 'block' &&
                              config.enablePageBlocking !== false;
+          const outcome = shouldBlock
+            ? "blocked"
+            : squattingAction === 'log'
+              ? "logged"
+              : "warned";
           logger.debug(`  shouldBlock: ${shouldBlock}`);
-          
+          logger.debug(`  outcome: ${outcome}`);
+
           // Log domain squatting detection
           logProtectionEvent({
             type: "threat_detected",
-            action: shouldBlock ? "blocked" : "warned",
+            action: outcome,
             url: location.href,
             origin: currentOrigin,
             reason: `Domain squatting detected: ${squattingData.techniques.map(t => t.description).join('; ')}`,
@@ -4282,7 +4292,7 @@ if (window.checkExtensionLoaded) {
             })),
             severity: squattingData.severity,
             confidence: squattingData.confidence,
-            action: shouldBlock ? "blocked" : "warned",
+            action: outcome,
             reason: `Domain squatting detected: ${squattingData.techniques.map(t => t.description).join('; ')}`
           });
           
@@ -4301,7 +4311,7 @@ if (window.checkExtensionLoaded) {
                 })),
                 severity: squattingData.severity,
                 confidence: squattingData.confidence,
-                action: shouldBlock ? "blocked" : "warned",
+                action: outcome,
                 reason: `Domain squatting detected: ${squattingData.techniques.map(t => t.description).join('; ')}`
               },
             })
@@ -4330,6 +4340,9 @@ if (window.checkExtensionLoaded) {
               }
             );
             return; // Stop processing, page is blocked
+          } else if (squattingAction === 'log') {
+            // Log-only action: telemetry has already been emitted above.
+            // Intentionally show nothing to the user. Log must not warn.
           } else if (showNotifications) {
             // Show warning banner for domain squatting (only if notifications enabled)
             const techniquesDesc = squattingData.techniques.map(t => 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -3411,9 +3411,15 @@ if (window.checkExtensionLoaded) {
       escaped = "^" + escaped;
     }
 
-    // Add end anchor if pattern doesn't end with wildcard
+    // Add end anchor if pattern doesn't end with wildcard. Tolerate an
+    // optional trailing path, query, or fragment so that allowlisting a host
+    // or a root URL (with or without a trailing slash) also matches deep
+    // links such as https://host/path. A single trailing slash in the pattern
+    // is normalized so it does not force an exact match on the bare root URL.
+    // Suffix tricks (for example https://host.evil.com/) still do not match,
+    // because the tolerated remainder must begin with /, ?, or #.
     if (!pattern.endsWith("*") && !escaped.endsWith(".*")) {
-      escaped = escaped + "$";
+      escaped = escaped.replace(/\/$/, "") + "(?:[/?#].*)?$";
     }
 
     return escaped;


### PR DESCRIPTION
This pull request introduces more precise and flexible handling of domain squatting detection actions, including better support for "log-only" mode, and improves the accuracy and clarity of allowlist pattern matching. The documentation has been updated to reflect these behavioral changes, and the code now distinguishes between blocking, warning, and silent logging actions, ensuring that user-facing warnings are never shown when "log" is selected.

**Domain squatting detection behavior and configuration:**

* Added support for a new `action: "log"` option in domain squatting detection, which records detections silently without showing banners or blocking pages. Documentation and configuration instructions have been updated to describe all three possible actions: `block`, `warn`, and `log`. [[1]](diffhunk://#diff-dad8c5d8faf1d3331cffc3654436d2fa692cd1d039a2ae40d90487bedcf70abeL91-R98) [[2]](diffhunk://#diff-dad8c5d8faf1d3331cffc3654436d2fa692cd1d039a2ae40d90487bedcf70abeL112-R113) [[3]](diffhunk://#diff-dad8c5d8faf1d3331cffc3654436d2fa692cd1d039a2ae40d90487bedcf70abeL121-R122)
* Updated `scripts/content.js` to resolve the effective action as a true three-state value (`block`, `warn`, `log`), ensuring telemetry and user notifications are handled according to the selected action. No warnings or blocks are shown when `log` is selected. [[1]](diffhunk://#diff-ca434d745a70ea67e88f5b35c70a2e4979d118951e2093aee59d72d1f5ff4c5cL4251-R4288) [[2]](diffhunk://#diff-ca434d745a70ea67e88f5b35c70a2e4979d118951e2093aee59d72d1f5ff4c5cL4285-R4311) [[3]](diffhunk://#diff-ca434d745a70ea67e88f5b35c70a2e4979d118951e2093aee59d72d1f5ff4c5cL4304-R4330) [[4]](diffhunk://#diff-ca434d745a70ea67e88f5b35c70a2e4979d118951e2093aee59d72d1f5ff4c5cR4359-R4361)

**Allowlist pattern matching improvements:**

* Refined the logic in both `options/options.js` and `scripts/content.js` for converting allowlist patterns to regular expressions. Host or root URL patterns now match deep links more intuitively, while patterns with explicit paths remain exact matches, preventing unintended broadening of allowlist entries. [[1]](diffhunk://#diff-e67ada59d53dfe71d2958851aae6e3de466e60d0dd9b489e24f28a7a9c2a51bbL1374-R1386) [[2]](diffhunk://#diff-ca434d745a70ea67e88f5b35c70a2e4979d118951e2093aee59d72d1f5ff4c5cL3414-R3432)

Fixes: #161 
Fixes: #162 