### PR TITLE
fix(enterprise): correct domainSquattingEnabled replacement pattern

### DIFF
--- a/enterprise/Setup-Windows-Chrome-and-Edge.ps1
+++ b/enterprise/Setup-Windows-Chrome-and-Edge.ps1
@@ -227,7 +227,7 @@ $replacements = @(
     @{ Pattern = '$cippTenantId = "" #';             Value = "`$cippTenantId = $(Format-SingleQuoted $cfg_cippTenantId) #" }
     @{ Pattern = '$customRulesUrl = "" #';           Value = "`$customRulesUrl = $(Format-SingleQuoted $cfg_customRulesUrl) #" }
     @{ Pattern = '$updateInterval = 24 #';           Value = "`$updateInterval = $cfg_updateInterval #" }
-    @{ Pattern = '$domainSquattingEnabled = 1 #';    Value = "`$domainSquattingEnabled = $cfg_domainSquattingEnabled #" }
+    @{ Pattern = '$domainSquattingEnabled = 0 #';    Value = "`$domainSquattingEnabled = $cfg_domainSquattingEnabled #" }
     @{ Pattern = '$enableDebugLogging = 0 #';        Value = "`$enableDebugLogging = $cfg_enableDebugLogging #" }
     @{ Pattern = '$enableGenericWebhook = 0 #';      Value = "`$enableGenericWebhook = $cfg_enableGenericWebhook #" }
     @{ Pattern = '$webhookUrl = "" #';               Value = "`$webhookUrl = $(Format-SingleQuoted $cfg_webhookUrl) #" }


### PR DESCRIPTION
## Problem

`Setup-Windows-Chrome-and-Edge.ps1` fails for every user with:

```
Failed to customize the Deploy template; the following expected pattern(s) were not found:
  - $domainSquattingEnabled = 1 #
The upstream template format may have changed.
```

The replacement map searched for `$domainSquattingEnabled = 1 #`, but both templates ship the setting as `= 0 #`:

- `Deploy-Windows-Chrome-and-Edge.ps1:25`
- `Detect-Windows-Chrome-and-Edge.ps1:34`

`Apply-Replacements` matches with `String.Contains`, so the lookup missed, the pattern was added to `$missing`, and the script threw before writing any output files. Nothing was produced for Intune.

This was unrelated to the answers given at the prompts. The script's own prompt default for this setting is already `"0"`, so only the pattern literal was wrong.

## Fix

One line: the pattern now reads `$domainSquattingEnabled = 0 #`, matching the templates.

## Verification

- Downloaded the current `Deploy`, `Detect`, and `Remove` templates from `refs/heads/main` and checked all 23 replacement patterns against them. This was the only mismatch.
- Ran the real replacement block from the edited script end to end against both templates: every replacement applies, and both generated scripts parse cleanly via `Parser::ParseInput`.
- Confirmed single-quote escaping still holds for user input (`O'Brien IT` renders as `'O''Brien IT'`).

## Note for maintainers

Each pattern hardcodes the template's *current default value*, so any future change to a default will break setup with this same exception. Anchoring on `$varName = ` through to ` #` would make the matching value-agnostic. Happy to follow up with that if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
